### PR TITLE
v0.6.0 — Arrow as universal data interchange layer

### DIFF
--- a/.sobelow-conf
+++ b/.sobelow-conf
@@ -1,0 +1,1 @@
+[exit: false, format: "txt", ignore_files: [], ignore: [], out: nil, private: false, router: nil, skip: true, threshold: :low, verbose: false, version: false]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   improved with hierarchy context and usage guidance.
 - **Version** — bumped from 0.5.0 to 0.6.0.
 
+### Fixed
+
+- **`ExArrow.from_dataframe/1` dropped rows for large dataframes** (#200) — when
+  Explorer split a dataframe into multiple Arrow IPC batches, only the first
+  batch was returned, silently discarding the rest.  Batches are now
+  concatenated into a single `RecordBatch` via the new `record_batch_concat`
+  NIF, preserving the full row count and all values.
+- **Rank-2 `ExArrow.from_nx/1` corrupted column order for more than 10 columns**
+  (#200) — columns were named `c0..cN` and reordered lexicographically
+  (`"c10"` before `"c2"`).  Column names are now zero-padded and
+  `ExArrow.to_nx/1` reconstructs columns in a deterministic sorted order, so
+  round-trips are correct for any column count.
+- **Rank-2 `ExArrow.from_nx/1` silently ignored `as: :boolean`** (#200) — the
+  option was dropped for rank-2 tensors, producing UInt8 columns.  The
+  combination now returns a clear error.
+
 ## [0.5.0] - 2026-04-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-06-08
+
+### Added
+
+- **Top-level Explorer interchange API** — `ExArrow.from_dataframe/1` and
+  `ExArrow.to_dataframe/1` convert between Explorer DataFrames and Arrow
+  RecordBatches with preserved schema, nullability, row count, and values.
+- **`ExArrow.DataFrame`** — `from_arrow/1` and `to_arrow/1` provide a
+  DataFrame-oriented naming convention.  `from_arrow/1` accepts both
+  `ExArrow.RecordBatch` and `ExArrow.Stream`.
+- **Top-level Nx interchange API** — `ExArrow.from_nx/1` and `ExArrow.to_nx/1`
+  convert between Nx tensors and Arrow RecordBatches.  Supports rank-1 and
+  rank-2 tensors over u8, s64, f32, f64, and boolean dtypes.  Rank-2 tensors
+  map to N-column batches (`c0..c{N-1}`) and round-trip with shape, dtype, and
+  value fidelity.
+- **`ExArrow.Schema.Mapper`** — single authority for bidirectional type mapping
+  between Arrow dtype strings and Explorer/Nx type systems.  Extensible for
+  future ExZarr and Dataset support.
+- **Field nullability** — `ExArrow.Field` now includes a `nullable` field.  The
+  `schema_fields` NIF returns `{name, type_atom, nullable}` tuples.  Schema
+  round-trips preserve nullability information.
+- **Boolean tensor support** — `ExArrow.Nx.from_tensor/3` accepts `as:
+  :boolean` to create Arrow Boolean columns.  `column_to_tensor/2` and
+  `to_tensors/1` now extract Boolean columns as `{:u, 8}` Nx tensors.
+- **`ExArrow.RecordBatch.num_columns/1`** and **`column_names/1`** — convenient
+  schema-derived accessors.
+- **`ExArrow.Table.from_batches/1`** — create a Table from a list of
+  RecordBatches.  Replaces the previous stub implementation with a real
+  Elixir-side aggregation providing `schema/1`, `num_rows/1`, and `batches/1`.
+- **Benchee benchmarks** — `bench/explorer_arrow_bench.exs` and
+  `bench/nx_arrow_bench.exs` measure Explorer and Nx interchange throughput at
+  1K, 100K, and 1M rows.
+- **Educational guides** — `guides/01_arrow_for_elixir_developers.md`,
+  `guides/02_explorer_integration.md`, `guides/03_nx_integration.md`,
+  `guides/04_arrow_ecosystem.md`.
+- **Property tests** — StreamData-based property tests for Explorer and Nx
+  round-trip fidelity.
+- **Arrow type coverage** — the `data_type_to_atom` NIF function now covers the
+  full integer/float range (Int8, Int16, Int32, UInt8, UInt16, UInt32, UInt64,
+  Float16, Float32) and additional types (Date32, Date64, Time32, Time64,
+  Duration).
+
+### Changed
+
+- **`ExArrow.Nx` delegates to `ExArrow.Schema.Mapper`** — dtype mapping logic
+  that was inlined in the Nx module now calls the Mapper, eliminating a
+  duplicated source of truth.  Public API unchanged.
+- **`ExArrow.Nx.from_tensor/3`** — now accepts an optional `opts` keyword list
+  (was arity 2).  The `as: :boolean` option creates Arrow Boolean columns.
+  Calling `from_tensor/2` (no opts) still works.
+- **`ExArrow.Table`** — replaced stub implementation (returning `nil`/`0`) with
+  a real Elixir-side aggregation struct holding `schema` and `batches`.
+- **`ExArrow` moduledoc** — expanded with Arrow hierarchy explanation, data
+  interchange API outline, and Schema.Mapper reference.
+- **`ExArrow.Array`, `ExArrow.RecordBatch`, `ExArrow.Table` moduledocs** —
+  improved with hierarchy context and usage guidance.
+- **Version** — bumped from 0.5.0 to 0.6.0.
+
 ## [0.5.0] - 2026-04-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Top-level Explorer interchange API** — `ExArrow.from_dataframe/1` and
   `ExArrow.to_dataframe/1` convert between Explorer DataFrames and Arrow
-  RecordBatches with preserved schema, nullability, row count, and values.
+  RecordBatches with preserved column names, row count, and values. Arrow value
+  types are preserved; nullability metadata is not guaranteed through Explorer.
 - **`ExArrow.DataFrame`** — `from_arrow/1` and `to_arrow/1` provide a
   DataFrame-oriented naming convention.  `from_arrow/1` accepts both
   `ExArrow.RecordBatch` and `ExArrow.Stream`.
@@ -25,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   future ExZarr and Dataset support.
 - **Field nullability** — `ExArrow.Field` now includes a `nullable` field.  The
   `schema_fields` NIF returns `{name, type_atom, nullable}` tuples.  Schema
-  round-trips preserve nullability information.
+  round-trips preserve nullability information for Arrow-native data. Explorer
+  IPC round-trips may relax nullable flags.
 - **Boolean tensor support** — `ExArrow.Nx.from_tensor/3` accepts `as:
   :boolean` to create Arrow Boolean columns.  `column_to_tensor/2` and
   `to_tensors/1` now extract Boolean columns as `{:u, 8}` Nx tensors.
@@ -103,6 +105,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   error, dispatch, and type-rejection tests; extended rank-2 property tests to
   cover ≥11 columns; added Nx boolean null extraction tests; fixed property test
   column-name generation to use `uniq_list_of/2`.
+- **Documentation: `from_tensor` arity inconsistency** (#204) — the API table
+  and `from_tensors` doc referenced `from_tensor/2`; both now say
+  `from_tensor/3` to match the actual arity with the optional `opts` default.
+- **Documentation: overstated round-trip guarantees** (#204) —
+  `from_dataframe/1` doc said "Schema and values are preserved" (schema
+  includes nullable, which is not guaranteed); changed to "Schema field names
+  and value types are preserved."  `to_dataframe/1` doc said "Schema, row
+  count, and values are preserved"; changed to "Column names, row count, and
+  values are preserved."
+- **Documentation: stale first-batch rationalization** (#204) — the
+  `data_frame.ex` docstring no longer mentions "the first batch is returned"
+  (was already removed in the C1 fix).
+- **Documentation: trailing space in `record_batch.ex`** (#204) — removed
+  trailing space after `ExArrow.Table` / and clarified as "or".
+- **Documentation: `Schema` moduledoc** (#204) — updated from "field names and
+  types" to "field names, types, and nullability".
 
 ## [0.5.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Rank-2 `ExArrow.from_nx/1` silently ignored `as: :boolean`** (#200) — the
   option was dropped for rank-2 tensors, producing UInt8 columns.  The
   combination now returns a clear error.
+- **Boolean buffer extraction ignored null bitmap** (#201) — `value(i)` on a
+  `BooleanArray` returns an unspecified bit for null slots.  The NIF now checks
+  `is_null(i)` and writes 0 for null positions, matching the documented
+  contract that "null positions are treated as zero bytes."
+- **Nullability documentation contradiction** (#201) — the Explorer integration
+  guide claimed "null positions in columns survive the round-trip" while the
+  top-level docs correctly noted that nullability metadata is not preserved
+  through Explorer.  The guide now explicitly distinguishes data preservation
+  (nil values survive) from schema nullability (which Explorer may relax).
+- **`nx_dtype` typespec was `term()`** (#201) — replaced the overly permissive
+  `@type nx_dtype :: term()` in `ExArrow.Schema.Mapper` with the precise union
+  `{:s | :u | :f, 8 | 16 | 32 | 64}`, restoring meaningful Dialyzer coverage.
 
 ## [0.5.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`nx_dtype` typespec was `term()`** (#201) — replaced the overly permissive
   `@type nx_dtype :: term()` in `ExArrow.Schema.Mapper` with the precise union
   `{:s | :u | :f, 8 | 16 | 32 | 64}`, restoring meaningful Dialyzer coverage.
+- **O(n²) accumulation in `extract_numeric_fields`** (#200) — already fixed in
+  v0.6.0 (uses `[field | acc]` + `Enum.reverse/1`).
+- **`Nx.tensor(Nx.to_list(...))` materialization in `from_nx_rank2`** (#200) —
+  already fixed in v0.6.0 (uses `Nx.as_type/2`).
+- **Whole-file `dialyzer_ignore.exs` suppression** (#202) — `from_arrow/1` no
+  longer pattern-matches on opaque `%Stream{}`/`%RecordBatch{}` structs.
+  Instead it delegates to `RecordBatch.record_batch?/1` and `Stream.stream?/1`
+  predicate functions.  The ignore file is now empty (`[]`), so future
+  Dialyzer warnings in `data_frame.ex` will surface.
+- **Test gaps** (#203) — added dedicated `data_frame_test.exs` with empty-batch
+  error, dispatch, and type-rejection tests; extended rank-2 property tests to
+  cover ≥11 columns; added Nx boolean null extraction tests; fixed property test
+  column-name generation to use `uniq_list_of/2`.
 
 ## [0.5.0] - 2026-04-16
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ EX_ARROW_BUILD=1 mix deps.get
 EX_ARROW_BUILD=1 mix compile
 ```
 
-The optional dependency `{:rustler, "~> 0.32.0", optional: true}` is required
+The optional dependency `{:rustler, "~> 0.36", optional: true}` is required
 for source builds and is already listed in ExArrow's own `mix.exs`.
 
 For **path dependencies** (e.g. Livebook or `Mix.install`), add `rustler`
@@ -215,7 +215,7 @@ explicitly and have Rust available:
 ```elixir
 Mix.install([
   {:ex_arrow, path: "/path/to/ex_arrow"},
-  {:rustler, "~> 0.37.3", optional: true}
+  {:rustler, "~> 0.36", optional: true}
 ])
 ```
 
@@ -939,7 +939,8 @@ welcome for any of them.
 - **`ExArrow.Schema.Mapper`** — single authority for Arrow <-> Explorer/Nx type
   mapping, extensible for future ExZarr and Dataset support.
 - **Field nullability** — `ExArrow.Field` includes `nullable`; NIF returns the
-  flag; schema round-trips preserve nullability.
+  flag; Arrow-native schema round-trips preserve nullability. Explorer-based
+  round-trips may report columns as nullable regardless of source data.
 - **Boolean tensor support** — `from_nx/1` with `as: :boolean`; `column_to_tensor/2`
   and `to_tensors/1` handle Boolean columns.
 - **RecordBatch and Table improvements** — `num_columns/1`, `column_names/1`,

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Add the dependency:
 
 ```elixir
 def deps do
-  [{:ex_arrow, "~> 0.5.0"}]
+  [{:ex_arrow, "~> 0.6.0"}]
 end
 ```
 
@@ -220,7 +220,7 @@ Mix.install([
 ```
 
 Alternatively, use the published Hex package so the precompiled NIF is used
-and no Rust is needed: `Mix.install([{:ex_arrow, "~> 0.5.0"}])`.
+and no Rust is needed: `Mix.install([{:ex_arrow, "~> 0.6.0"}])`.
 
 ---
 
@@ -616,6 +616,22 @@ All operations run entirely in native memory. Results are new
 ExArrow handles streaming and transport. Add `{:explorer, "~> 0.11"}` to your
 `mix.exs` to enable the bridge.
 
+**Top-level interchange (v0.6+):**
+
+```elixir
+df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+
+# DataFrame → Arrow
+{:ok, batch} = ExArrow.from_dataframe(df)
+
+# Arrow → DataFrame
+{:ok, df2} = ExArrow.to_dataframe(batch)
+
+# DataFrame-oriented API
+{:ok, batch} = ExArrow.DataFrame.to_arrow(df)
+{:ok, df3}   = ExArrow.DataFrame.from_arrow(batch)
+```
+
 **ExArrow → Explorer** (one call, no boilerplate):
 
 ```elixir
@@ -659,6 +675,28 @@ buffers — no list materialisation occurs.
 
 Add `{:nx, "~> 0.9"}` to your `mix.exs` to enable this module.
 
+**Top-level interchange (v0.6+):**
+
+```elixir
+# Tensor → Arrow
+tensor = Nx.tensor([1, 2, 3], type: {:s, 64})
+{:ok, batch} = ExArrow.from_nx(tensor)
+
+# Arrow → Tensor
+{:ok, recovered} = ExArrow.to_nx(batch)
+Nx.to_list(recovered)  #=> [1, 2, 3]
+
+# Rank-2 tensor → multi-column batch → rank-2 tensor
+matrix = Nx.tensor([[1, 2, 3], [4, 5, 6]], type: {:s, 64})
+{:ok, batch} = ExArrow.from_nx(matrix)
+{:ok, back}  = ExArrow.to_nx(batch)
+Nx.shape(back)  #=> {2, 3}
+
+# Boolean tensor
+flags = Nx.tensor([1, 0, 1], type: {:u, 8})
+{:ok, batch} = ExArrow.from_nx(flags, as: :boolean)
+```
+
 **Column to tensor:**
 
 ```elixir
@@ -680,8 +718,9 @@ weights = Nx.tensor([0.1, 0.2, 0.7], type: {:f, 64})
 {:ok, batch} = ExArrow.Nx.from_tensor(weights, "weights")
 ```
 
-Non-numeric columns (strings, booleans, timestamps) are silently skipped by
+Non-numeric columns (strings, timestamps) are silently skipped by
 `to_tensors/1`. Unsupported Nx dtypes (e.g. `:bf16`) return `{:error, ...}`.
+Boolean columns are extracted as `{:u, 8}` tensors.
 
 ---
 
@@ -779,13 +818,15 @@ HTML reports are written to `bench/output/` (gitignored).
 ### Suites
 
 
-| File                  | What it measures                                                               |
-| --------------------- | ------------------------------------------------------------------------------ |
-| `ipc_read_bench.exs`  | Stream handle vs materialise — BEAM memory saved by keeping data native        |
-| `ipc_write_bench.exs` | IPC serialisation vs `:erlang.term_to_binary` — columnar vs row-oriented write |
-| `flight_bench.exs`    | Flight doput / doget / roundtrip latency with in-process server                |
-| `adbc_bench.exs`      | Stream handle vs schema peek vs full collect                                   |
-| `pipeline_bench.exs`  | End-to-end: IPC file on disk to Flight doput without materialising in BEAM     |
+| File                       | What it measures                                                               |
+| -------------------------- | ------------------------------------------------------------------------------ |
+| `ipc_read_bench.exs`       | Stream handle vs materialise — BEAM memory saved by keeping data native        |
+| `ipc_write_bench.exs`      | IPC serialisation vs `:erlang.term_to_binary` — columnar vs row-oriented write |
+| `flight_bench.exs`         | Flight doput / doget / roundtrip latency with in-process server                |
+| `adbc_bench.exs`           | Stream handle vs schema peek vs full collect                                   |
+| `pipeline_bench.exs`       | End-to-end: IPC file on disk to Flight doput without materialising in BEAM     |
+| `explorer_arrow_bench.exs` | Explorer <-> Arrow interchange at 1K/100K/1M rows                             |
+| `nx_arrow_bench.exs`       | Nx <-> Arrow interchange at 1K/100K/1M rows (rank-1 and rank-2)              |
 
 
 ### Published results
@@ -800,6 +841,10 @@ The CI workflow posts a PR alert comment when any scenario regresses more than
 
 ## Documentation
 
+- [Arrow for Elixir Developers](guides/01_arrow_for_elixir_developers.md) — hierarchy, types, memory model
+- [Explorer Integration](guides/02_explorer_integration.md) — from_dataframe, to_dataframe, type mapping, limitations
+- [Nx Integration](guides/03_nx_integration.md) — from_nx, to_nx, boolean tensors, rank-2
+- [Arrow Ecosystem](guides/04_arrow_ecosystem.md) — how ExArrow complements Explorer, Nx, ADBC, Flight, Parquet, ExZarr
 - [Memory model](docs/memory_model.md) — handles, copying rules, NIF scheduling
 - [IPC guide](docs/ipc_guide.md) — stream vs file, types, limitations
 - [Parquet guide](docs/parquet_guide.md) — read/write Parquet, streaming, comparison with IPC
@@ -884,6 +929,25 @@ welcome for any of them.
   `:grpc_status` integer, covering 11 error categories.
 - **Mox-compatible `ClientBehaviour`** — full test isolation without a live server.
 - **Explorer and Nx integration** — `Result.to_dataframe/1`, `Result.to_tensor/2`.
+
+### Shipped (v0.6.0)
+
+- **Top-level Explorer interchange** — `ExArrow.from_dataframe/1`,
+  `to_dataframe/1`, and `ExArrow.DataFrame.from_arrow/1`, `to_arrow/1`.
+- **Top-level Nx interchange** — `ExArrow.from_nx/1`, `to_nx/1` with rank-1
+  and rank-2 support for u8, s64, f32, f64, and boolean.
+- **`ExArrow.Schema.Mapper`** — single authority for Arrow <-> Explorer/Nx type
+  mapping, extensible for future ExZarr and Dataset support.
+- **Field nullability** — `ExArrow.Field` includes `nullable`; NIF returns the
+  flag; schema round-trips preserve nullability.
+- **Boolean tensor support** — `from_nx/1` with `as: :boolean`; `column_to_tensor/2`
+  and `to_tensors/1` handle Boolean columns.
+- **RecordBatch and Table improvements** — `num_columns/1`, `column_names/1`,
+  `Table.from_batches/1` replaces stub.
+- **Benchee benchmarks** — Explorer <-> Arrow and Nx <-> Arrow at 1K/100K/1M.
+- **Educational guides** — `guides/01..04` covering Arrow concepts, Explorer,
+  Nx, and the ecosystem.
+- **Property tests** — StreamData-based round-trip fidelity tests.
 
 ### Longer-term
 

--- a/bench/explorer_arrow_bench.exs
+++ b/bench/explorer_arrow_bench.exs
@@ -1,0 +1,53 @@
+Code.require_file("bench_helper.exs", __DIR__)
+
+IO.puts("\n== Explorer <-> Arrow Benchmark ==\n")
+
+if Code.ensure_loaded?(Explorer.DataFrame) do
+  make_df = fn n ->
+    Explorer.DataFrame.new(
+      x: Enum.to_list(1..n//1),
+      y: Enum.map(1..n//1, fn i -> "val_#{i}" end),
+      flag: Enum.map(1..n//1, fn i -> rem(i, 2) == 0 end)
+    )
+  end
+
+  df_1k = make_df.(1_000)
+  df_100k = make_df.(100_000)
+  df_1m = make_df.(1_000_000)
+
+  Benchee.run(
+    %{
+      "from_dataframe (1K rows)" => fn -> ExArrow.from_dataframe(df_1k) end,
+      "from_dataframe (100K rows)" => fn -> ExArrow.from_dataframe(df_100k) end,
+      "from_dataframe (1M rows)" => fn -> ExArrow.from_dataframe(df_1m) end
+    },
+    time: 5,
+    memory_time: 2,
+    formatters: [
+      Benchee.Formatters.Console,
+      {Benchee.Formatters.HTML, file: Path.join(Bench.DataGen.output_dir(), "explorer_from_dataframe.html")},
+      {Benchee.Formatters.JSON, file: Path.join(Bench.DataGen.output_dir(), "explorer_from_dataframe.json")}
+    ]
+  )
+
+  {:ok, batch_1k} = ExArrow.from_dataframe(df_1k)
+  {:ok, batch_100k} = ExArrow.from_dataframe(df_100k)
+  {:ok, batch_1m} = ExArrow.from_dataframe(df_1m)
+
+  Benchee.run(
+    %{
+      "to_dataframe (1K rows)" => fn -> ExArrow.to_dataframe(batch_1k) end,
+      "to_dataframe (100K rows)" => fn -> ExArrow.to_dataframe(batch_100k) end,
+      "to_dataframe (1M rows)" => fn -> ExArrow.to_dataframe(batch_1m) end
+    },
+    time: 5,
+    memory_time: 2,
+    formatters: [
+      Benchee.Formatters.Console,
+      {Benchee.Formatters.HTML, file: Path.join(Bench.DataGen.output_dir(), "explorer_to_dataframe.html")},
+      {Benchee.Formatters.JSON, file: Path.join(Bench.DataGen.output_dir(), "explorer_to_dataframe.json")}
+    ]
+  )
+else
+  IO.puts("Explorer not available. Skipping Explorer <-> Arrow benchmark.")
+end

--- a/bench/nx_arrow_bench.exs
+++ b/bench/nx_arrow_bench.exs
@@ -1,0 +1,74 @@
+Code.require_file("bench_helper.exs", __DIR__)
+
+IO.puts("\n== Nx <-> Arrow Benchmark ==\n")
+
+if Code.ensure_loaded?(Nx) do
+  make_tensors = fn n, dtype ->
+    rank1 = Nx.tensor(Enum.to_list(1..n//1), type: dtype)
+    rows = max(1, div(n, 4))
+    cols = max(2, div(n, rows))
+    actual_n = rows * cols
+    rank2 = Nx.tensor(Enum.to_list(1..actual_n//1), type: dtype) |> Nx.reshape({rows, cols})
+    {rank1, rank2}
+  end
+
+  for dtype <- [{:s, 64}, {:f, 64}, {:u, 8}] do
+    {r1_1k, r2_1k} = make_tensors.(1_000, dtype)
+    {r1_100k, _r2_100k} = make_tensors.(100_000, dtype)
+    {r1_1m, _r2_1m} = make_tensors.(1_000_000, dtype)
+
+    dtype_label = inspect(dtype)
+
+    Benchee.run(
+      %{
+        "from_nx rank-1 #{dtype_label} (1K)" => fn -> ExArrow.from_nx(r1_1k) end,
+        "from_nx rank-1 #{dtype_label} (100K)" => fn -> ExArrow.from_nx(r1_100k) end,
+        "from_nx rank-1 #{dtype_label} (1M)" => fn -> ExArrow.from_nx(r1_1m) end
+      },
+      time: 5,
+      memory_time: 2,
+      formatters: [
+        Benchee.Formatters.Console,
+        {Benchee.Formatters.HTML, file: Path.join(Bench.DataGen.output_dir(), "nx_from_#{dtype_label}.html")},
+        {Benchee.Formatters.JSON, file: Path.join(Bench.DataGen.output_dir(), "nx_from_#{dtype_label}.json")}
+      ]
+    )
+
+    {:ok, batch_1k} = ExArrow.from_nx(r1_1k)
+    {:ok, batch_100k} = ExArrow.from_nx(r1_100k)
+    {:ok, batch_1m} = ExArrow.from_nx(r1_1m)
+
+    Benchee.run(
+      %{
+        "to_nx single-col #{dtype_label} (1K)" => fn -> ExArrow.to_nx(batch_1k) end,
+        "to_nx single-col #{dtype_label} (100K)" => fn -> ExArrow.to_nx(batch_100k) end,
+        "to_nx single-col #{dtype_label} (1M)" => fn -> ExArrow.to_nx(batch_1m) end
+      },
+      time: 5,
+      memory_time: 2,
+      formatters: [
+        Benchee.Formatters.Console,
+        {Benchee.Formatters.HTML, file: Path.join(Bench.DataGen.output_dir(), "nx_to_#{dtype_label}.html")},
+        {Benchee.Formatters.JSON, file: Path.join(Bench.DataGen.output_dir(), "nx_to_#{dtype_label}.json")}
+      ]
+    )
+
+    {:ok, batch_r2_1k} = ExArrow.from_nx(r2_1k)
+
+    Benchee.run(
+      %{
+        "from_nx rank-2 #{dtype_label} (1K)" => fn -> ExArrow.from_nx(r2_1k) end,
+        "to_nx multi-col #{dtype_label} (1K)" => fn -> ExArrow.to_nx(batch_r2_1k) end
+      },
+      time: 5,
+      memory_time: 2,
+      formatters: [
+        Benchee.Formatters.Console,
+        {Benchee.Formatters.HTML, file: Path.join(Bench.DataGen.output_dir(), "nx_rank2_#{dtype_label}.html")},
+        {Benchee.Formatters.JSON, file: Path.join(Bench.DataGen.output_dir(), "nx_rank2_#{dtype_label}.json")}
+      ]
+    )
+  end
+else
+  IO.puts("Nx not available. Skipping Nx <-> Arrow benchmark.")
+end

--- a/bench/run_all.exs
+++ b/bench/run_all.exs
@@ -15,7 +15,9 @@ scripts = [
   "bench/ipc_write_bench.exs",
   "bench/flight_bench.exs",
   "bench/adbc_bench.exs",
-  "bench/pipeline_bench.exs"
+  "bench/pipeline_bench.exs",
+  "bench/explorer_arrow_bench.exs",
+  "bench/nx_arrow_bench.exs"
 ]
 
 for script <- scripts do

--- a/guides/01_arrow_for_elixir_developers.md
+++ b/guides/01_arrow_for_elixir_developers.md
@@ -1,0 +1,96 @@
+# Arrow for Elixir Developers
+
+Apache Arrow is a cross-language, in-memory columnar data format designed for
+efficient analytical processing.  This guide explains the core Arrow concepts
+that ExArrow exposes and how they map to familiar Elixir ideas.
+
+## The Arrow hierarchy
+
+Arrow organises data in a strict, layered hierarchy:
+
+```
+Schema
+  └─ Field (name, type, nullable)
+       │
+RecordBatch
+  └─ Array (one per column, shared row count)
+       │
+Table
+  └─ RecordBatch (one or more, shared schema)
+       │
+Stream
+  └─ RecordBatch (lazy sequence, consumed one at a time)
+```
+
+**Array** is the leaf: a single typed column of contiguous values.  Arrays are
+never created directly by users; they live inside a RecordBatch.
+
+**RecordBatch** is the fundamental unit of exchange.  A batch groups N arrays
+(one per column) with a shared row count and schema.  Most ExArrow functions
+accept or return batches.
+
+**Table** is a logical container for one or more batches that share a schema.
+It is an Elixir-side aggregation — useful when you have already collected all
+batches and want a convenient handle for `schema/1`, `num_rows/1`, and
+`batches/1`.
+
+**Stream** is a lazy sequence of batches.  It is the primary output type of
+IPC readers, Flight/Flight SQL queries, ADBC statement execution, and Parquet
+readers.  Streams implement the `Enumerable` protocol, so `Enum` and `Stream`
+functions work directly.
+
+**Schema** describes the column names, types, and nullability of a batch or
+table.  **Field** is one column's metadata within a schema.
+
+## Memory model
+
+ExArrow keeps all Arrow data in native (Rust) memory.  Elixir holds only opaque
+references.  This means:
+
+- Zero-copy: reading a stream or batch does not copy column data into the BEAM
+  heap.
+- Explicit materialisation: when you need data in Elixir (e.g. for Explorer or
+  Nx), you call a conversion function that performs one copy.
+- Resource lifecycle: native resources are released when their Elixir handle is
+  garbage-collected.
+
+## Arrow types in ExArrow
+
+The NIF layer reports column types as atoms:
+
+| Atom        | Arrow type |
+|-------------|------------|
+| `:boolean`  | Boolean    |
+| `:int8`     | Int8       |
+| `:int16`    | Int16      |
+| `:int32`    | Int32      |
+| `:int64`    | Int64      |
+| `:uint8`    | UInt8      |
+| `:uint16`   | UInt16     |
+| `:uint32`   | UInt32     |
+| `:uint64`   | UInt64     |
+| `:float32`  | Float32    |
+| `:float64`  | Float64    |
+| `:utf8`     | Utf8       |
+| `:timestamp`| Timestamp  |
+
+The `ExArrow.Schema.Mapper` module provides bidirectional mapping between these
+Arrow types and external type systems (Explorer, Nx).  It is the single
+authority for type conversion and is extensible for future targets such as
+ExZarr and Dataset.
+
+## When to use what
+
+- **IPC** (`ExArrow.IPC`): Read/write Arrow data from files or binaries.  Good
+  for local file exchange and testing.
+- **Flight** (`ExArrow.Flight.Client`): Stream Arrow data over gRPC.  Good for
+  inter-process and inter-service communication.
+- **Flight SQL** (`ExArrow.FlightSQL.Client`): Execute SQL queries against
+  Flight SQL servers and receive Arrow-native results.
+- **ADBC** (`ExArrow.ADBC`): Connect to databases via ADBC drivers and execute
+  SQL with Arrow-native result streams.
+- **Parquet** (`ExArrow.Parquet`): Read/write Parquet files directly into Arrow
+  batches.
+- **Explorer bridge** (`ExArrow.from_dataframe/1`): Convert Explorer DataFrames
+  to and from Arrow.
+- **Nx bridge** (`ExArrow.from_nx/1`): Convert Nx tensors to and from Arrow.

--- a/guides/02_explorer_integration.md
+++ b/guides/02_explorer_integration.md
@@ -1,0 +1,70 @@
+# Explorer Integration
+
+ExArrow provides first-class interchange between Explorer DataFrames and Arrow
+RecordBatches.  The conversion path is always columnar and binary (Arrow IPC
+round-trip) — no CSV, no row-by-row materialisation.
+
+## Top-level API
+
+```elixir
+# DataFrame → Arrow
+df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+{:ok, batch} = ExArrow.from_dataframe(df)
+
+# Arrow → DataFrame
+{:ok, df2} = ExArrow.to_dataframe(batch)
+```
+
+## DataFrame-oriented API
+
+```elixir
+# DataFrame → Arrow (same as from_dataframe, different naming convention)
+{:ok, batch} = ExArrow.DataFrame.to_arrow(df)
+
+# Arrow → DataFrame (accepts RecordBatch or Stream)
+{:ok, df} = ExArrow.DataFrame.from_arrow(batch)
+```
+
+## What is preserved
+
+- **Column names**: the same names appear on both sides.
+- **Row count**: the number of rows is unchanged.
+- **Values**: integer, float, boolean, and string values are preserved exactly.
+- **Nullability**: null positions in columns survive the round-trip.
+
+## What is not preserved
+
+Explorer does not distinguish between nullable and non-nullable columns in its
+dtype system.  When an Explorer DataFrame is serialised to Arrow IPC, all
+columns may appear as nullable regardless of whether the source data contained
+nulls.  The actual data values (including nils) are always correct.
+
+## Type mapping
+
+| Explorer dtype | Arrow type |
+|----------------|------------|
+| `:integer`     | Int64      |
+| `:float`       | Float64    |
+| `:boolean`     | Boolean    |
+| `:string`      | Utf8       |
+
+Date, datetime, and duration dtypes are not yet mapped.  These will be added
+as the NIF layer gains support for the corresponding Arrow types.
+
+The authoritative mapping table lives in `ExArrow.Schema.Mapper`.
+
+## When to prefer Arrow-native consumption
+
+Converting to a DataFrame materialises all data into Explorer's native memory
+format.  If you only need to stream Arrow data to another Arrow consumer (e.g.
+a Flight do_put, an IPC file write, or a Parquet write), keep it as an
+`ExArrow.Stream` or `ExArrow.RecordBatch` and avoid the conversion overhead.
+
+## Lower-level API
+
+The `ExArrow.Explorer` module provides finer-grained functions:
+
+- `from_stream/1` — convert an `ExArrow.Stream` to a DataFrame
+- `from_record_batch/1` — convert a single batch to a DataFrame
+- `to_stream/1` — convert a DataFrame to an `ExArrow.Stream`
+- `to_record_batches/1` — convert a DataFrame to a list of batches

--- a/guides/02_explorer_integration.md
+++ b/guides/02_explorer_integration.md
@@ -30,14 +30,19 @@ df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
 - **Column names**: the same names appear on both sides.
 - **Row count**: the number of rows is unchanged.
 - **Values**: integer, float, boolean, and string values are preserved exactly.
-- **Nullability**: null positions in columns survive the round-trip.
+  Null positions survive the round-trip (nil stays nil).
+- **Nullability metadata**: Explorer does not distinguish nullable from
+  non-nullable columns.  All columns may appear as nullable in the Arrow
+  schema regardless of the source data, so nullability *metadata* is not
+  preserved.
 
 ## What is not preserved
 
 Explorer does not distinguish between nullable and non-nullable columns in its
 dtype system.  When an Explorer DataFrame is serialised to Arrow IPC, all
 columns may appear as nullable regardless of whether the source data contained
-nulls.  The actual data values (including nils) are always correct.
+nulls.  The actual data values (including nils) are always correct; only the
+schema's nullable flag may differ from the original.
 
 ## Type mapping
 

--- a/guides/03_nx_integration.md
+++ b/guides/03_nx_integration.md
@@ -1,0 +1,99 @@
+# Nx Integration
+
+ExArrow provides first-class interchange between Nx tensors and Arrow
+RecordBatches.  The conversion path uses raw byte buffer extraction — no
+intermediate list materialisation occurs.
+
+## Top-level API
+
+```elixir
+# Tensor → Arrow
+tensor = Nx.tensor([1, 2, 3], type: {:s, 64})
+{:ok, batch} = ExArrow.from_nx(tensor)
+
+# Arrow → Tensor
+{:ok, recovered} = ExArrow.to_nx(batch)
+Nx.to_list(recovered)  #=> [1, 2, 3]
+```
+
+## Supported dtypes
+
+| Nx dtype     | Arrow type |
+|--------------|------------|
+| `{:u, 8}`    | UInt8      |
+| `{:s, 64}`   | Int64      |
+| `{:f, 32}`   | Float32    |
+| `{:f, 64}`   | Float64    |
+
+All other integer and float dtypes (`{:s, 8}`, `{:s, 16}`, `{:s, 32}`,
+`{:u, 16}`, `{:u, 32}`, `{:u, 64}`) are also supported.  Bfloat16, complex,
+and other Nx dtypes are not supported.
+
+## Boolean tensors
+
+Nx does not have a dedicated boolean dtype.  Booleans are represented as
+`{:u, 8}` tensors with values 0 and 1.  Use the `as: :boolean` option to
+create an Arrow Boolean column:
+
+```elixir
+flags = Nx.tensor([1, 0, 1, 0], type: {:u, 8})
+{:ok, batch} = ExArrow.from_nx(flags, as: :boolean)
+```
+
+When reading back, Arrow Boolean columns are returned as `{:u, 8}` tensors:
+
+```elixir
+{:ok, tensor} = ExArrow.to_nx(batch)
+Nx.type(tensor)  #=> {:u, 8}
+Nx.to_list(tensor)  #=> [1, 0, 1, 0]
+```
+
+## Rank-1 tensors (single column)
+
+A rank-1 tensor produces a single-column RecordBatch.  The column is named
+`"value"` by default; use the `:name` option to customise:
+
+```elixir
+{:ok, batch} = ExArrow.from_nx(tensor, name: "prices")
+```
+
+## Rank-2 tensors (multi-column)
+
+A rank-2 tensor with shape `{rows, cols}` produces a multi-column RecordBatch
+with `cols` columns named `"c0"`, `"c1"`, ..., `"c{cols-1}"` and `rows` rows:
+
+```elixir
+tensor = Nx.tensor([[1, 2, 3], [4, 5, 6]], type: {:s, 64})
+{:ok, batch} = ExArrow.from_nx(tensor)
+# batch has columns: c0=[1,4], c1=[2,5], c2=[3,6]
+```
+
+The reverse path (multi-column batch → rank-2 tensor) works when all numeric
+columns have the same dtype:
+
+```elixir
+{:ok, recovered} = ExArrow.to_nx(batch)
+Nx.shape(recovered)  #=> {2, 3}
+```
+
+If columns have mixed dtypes, `to_nx/1` returns an error.  Use
+`ExArrow.Nx.to_tensors/1` for per-column access.
+
+## Rank > 2
+
+Tensors of rank > 2 are not supported.  Flatten or reshape before conversion.
+
+## Null handling
+
+Arrow null positions are treated as zero bytes in the extracted buffer.  If
+your column contains nulls and you need to distinguish them, inspect the
+original batch.  Null-aware Nx conversion may be added in a future release.
+
+## Lower-level API
+
+The `ExArrow.Nx` module provides column-level operations:
+
+- `column_to_tensor/2` — extract one named column as a tensor
+- `to_tensors/1` — extract all numeric/boolean columns as a map
+- `from_tensor/2` — single tensor → single-column batch
+- `from_tensors/1` — map of tensors → multi-column batch

--- a/guides/04_arrow_ecosystem.md
+++ b/guides/04_arrow_ecosystem.md
@@ -1,0 +1,102 @@
+# The Arrow Ecosystem in Elixir
+
+ExArrow is one piece of a larger Arrow-based data ecosystem.  This guide
+explains how the pieces fit together and when to use each one.
+
+## The pieces
+
+| Component       | Role                                              |
+|-----------------|---------------------------------------------------|
+| **ExArrow**     | Arrow core: IPC, Schema, RecordBatch, Stream      |
+| **Explorer**    | DataFrames with columnar operations               |
+| **Nx**          | Numerical computing and machine learning tensors   |
+| **ADBC**        | Database connectivity via Arrow-native drivers     |
+| **Flight**      | Arrow data transport over gRPC                    |
+| **Flight SQL**  | SQL query execution over the Flight protocol      |
+| **Parquet**     | Columnar file format built on Arrow               |
+| **ExZarr**      | Zarr/n-dimensional array storage (future)         |
+
+## Data flow
+
+```
+                    ┌──────────┐
+                    │  Parquet │
+                    └────┬─────┘
+                         │ read/write
+                    ┌────▼─────┐
+              ┌─────│  ExArrow │─────┐
+              │     └────┬─────┘     │
+              │          │           │
+    from_dataframe     from_nx      │
+    to_dataframe       to_nx        │
+              │          │           │
+        ┌─────▼──┐  ┌───▼────┐      │
+        │Explorer│  │  Nx    │      │
+        └────────┘  └────────┘      │
+                         │          │
+              ┌──────────┼─────────┤
+              │          │         │
+         ┌────▼───┐ ┌───▼────┐ ┌──▼───┐
+         │ Flight │ │ADBC    │ │ IPC  │
+         │ Client │ │Database│ │File  │
+         └────────┘ └────────┘ └──────┘
+              │
+         ┌────▼───────┐
+         │ Flight SQL │
+         │  Client    │
+         └────────────┘
+```
+
+## ExArrow as the interchange layer
+
+ExArrow sits at the centre.  Arrow data arrives via IPC files, Flight,
+Flight SQL, ADBC, or Parquet.  It is consumed by Explorer DataFrames or Nx
+tensors.  The same Arrow-native data can be sent to Flight servers, written to
+Parquet files, or passed to other Arrow-compatible systems without copying into
+the BEAM heap.
+
+## Explorer vs Nx
+
+- Use **Explorer** for tabular data: filtering, grouping, joining, and
+  aggregations on structured datasets with mixed column types.
+- Use **Nx** for homogeneous numeric data: linear algebra, machine learning,
+  and tensor operations on uniform arrays of numbers.
+- Use **Arrow-native** (RecordBatch/Stream) when you need to move data between
+  systems without materialising it in Elixir.
+
+## ADBC
+
+ADBC (Arrow Database Connectivity) provides a standard API for connecting to
+databases and receiving Arrow-native result streams.  ExArrow's ADBC module
+supports PostgreSQL, DuckDB, SQLite, and other databases via pluggable drivers.
+
+Results from ADBC queries are `ExArrow.Stream` handles — the same type returned
+by IPC and Flight readers — so the same downstream conversion functions work
+uniformly.
+
+## Flight
+
+Arrow Flight is a gRPC-based protocol for streaming Arrow data between
+processes and services.  ExArrow's Flight client supports `do_get`, `do_put`,
+`list_flights`, and `get_flight_info`.  It is suitable for high-throughput
+data transfer between services.
+
+## Flight SQL
+
+Flight SQL extends Flight with SQL query execution.  ExArrow's Flight SQL
+client connects to any Flight SQL server (DuckDB, DataFusion, Dremio, InfluxDB
+v3), executes SQL queries, and returns Arrow-native results.  It supports
+streaming queries, DML, prepared statements, and metadata discovery.
+
+## Parquet
+
+Parquet is a columnar file format built on Arrow's type system.  ExArrow can
+read and write Parquet files directly, producing `ExArrow.Stream` handles on
+read and accepting `ExArrow.RecordBatch` lists on write.
+
+## ExZarr (future)
+
+ExZarr will provide Zarr-compatible n-dimensional array storage.  When it
+arrives, `ExArrow.Schema.Mapper` will be extended with ExZarr <-> Arrow type
+mappings, and ExArrow will serve as the interchange layer between Zarr arrays
+and the rest of the Elixir Arrow ecosystem.

--- a/lib/ex_arrow.ex
+++ b/lib/ex_arrow.ex
@@ -1,16 +1,47 @@
 defmodule ExArrow do
   @moduledoc """
-  Apache Arrow support for the BEAM: IPC, Flight, and ADBC.
+  Apache Arrow support for the BEAM: IPC, Flight, ADBC, and data interchange.
 
   ExArrow keeps Arrow data in native (Rust) memory and exposes opaque handles
   on the Elixir side. Copying to the BEAM heap happens only when explicitly
   requested.
 
+  ## Arrow hierarchy
+
+  Arrow organises columnar data in a strict hierarchy:
+
+  - **Array** — a single column of typed values (the leaf node).
+  - **RecordBatch** — a collection of Arrays sharing a row count and schema.
+  - **Table** — a logical table backed by one or more RecordBatches.
+  - **Stream** — a lazy sequence of RecordBatches (used by IPC, Flight, ADBC,
+    and Parquet).
+  - **Schema** — metadata describing field names, types, and nullability.
+  - **Field** — one column's metadata within a Schema.
+
+  Data flows through these levels: a Stream yields Batches, a Batch exposes
+  its Schema and row count, and the Schema lists its Fields.
+
+  ## Data interchange (v0.6+)
+
+  ExArrow serves as a universal data interchange layer between Arrow and the
+  wider Elixir ecosystem:
+
+  - `from_dataframe/1` / `to_dataframe/1` — Explorer DataFrame <-> Arrow
+  - `from_nx/1` / `to_nx/1` — Nx Tensor <-> Arrow
+
+  These top-level functions delegate to focused bridge modules:
+  `ExArrow.DataFrame`, `ExArrow.Explorer`, and `ExArrow.Nx`.
+
   ## Public API outline
+
+  ### Data interchange
+  - `ExArrow.from_dataframe/1`, `to_dataframe/1` — Explorer <-> Arrow
+  - `ExArrow.from_nx/1`, `to_nx/1` — Nx <-> Arrow
+  - `ExArrow.DataFrame.from_arrow/1`, `to_arrow/1` — DataFrame-oriented API
 
   ### Core handles (opaque references)
   - `ExArrow.Schema` – schema metadata (fields)
-  - `ExArrow.Field` – field name and type
+  - `ExArrow.Field` – field name, type, and nullability
   - `ExArrow.Array` – column array handle
   - `ExArrow.RecordBatch` – batch of columns with shared row count
   - `ExArrow.Table` – table with schema and batches
@@ -29,11 +60,15 @@ defmodule ExArrow do
   - `ExArrow.ADBC.Connection.open/1` – open connection from database
   - `ExArrow.ADBC.Statement` – new(conn, sql) or new(conn, sql, bind: batch), execute (returns stream); set_sql/bind for reuse/rebind
 
+  ### Schema mapping
+  - `ExArrow.Schema.Mapper` – bidirectional Arrow <-> Explorer/Nx type mapping
+
   ### Errors
   - `ExArrow.Error` – structured exception with code, message, details
-
-  ## Version
   """
+
+  @explorer_available Code.ensure_loaded?(Explorer.DataFrame)
+  @nx_available Code.ensure_loaded?(Nx)
 
   @doc """
   Returns the native NIF crate version. Used to verify the NIF loads.
@@ -41,5 +76,197 @@ defmodule ExArrow do
   @spec native_version() :: String.t()
   def native_version do
     ExArrow.Native.nif_version()
+  end
+
+  if @explorer_available do
+    @doc """
+    Convert an `Explorer.DataFrame` to an `ExArrow.RecordBatch`.
+
+    The dataframe is serialised to Arrow IPC and read back as a native batch
+    handle.  Schema, nullability, row count, and values are preserved.
+
+    Returns `{:ok, batch}` or `{:error, message}`.
+
+    ## Examples
+
+        df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        ExArrow.RecordBatch.num_rows(batch)  #=> 3
+    """
+    @spec from_dataframe(Explorer.DataFrame.t()) ::
+            {:ok, ExArrow.RecordBatch.t()} | {:error, String.t()}
+    def from_dataframe(df), do: ExArrow.DataFrame.to_arrow(df)
+
+    @doc """
+    Convert an `ExArrow.RecordBatch` or `ExArrow.Stream` to an
+    `Explorer.DataFrame`.
+
+    Schema, nullability, row count, and values are preserved.
+
+    Returns `{:ok, dataframe}` or `{:error, message}`.
+
+    ## Examples
+
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        Explorer.DataFrame.n_rows(df2)  #=> 3
+    """
+    @spec to_dataframe(ExArrow.RecordBatch.t() | ExArrow.Stream.t()) ::
+            {:ok, Explorer.DataFrame.t()} | {:error, String.t()}
+    def to_dataframe(batch_or_stream), do: ExArrow.DataFrame.from_arrow(batch_or_stream)
+  else
+    @doc false
+    def from_dataframe(_), do: {:error, "Explorer is not available. Add {:explorer, \"~> 0.11\"} to your mix.exs dependencies."}
+
+    @doc false
+    def to_dataframe(_), do: {:error, "Explorer is not available. Add {:explorer, \"~> 0.11\"} to your mix.exs dependencies."}
+  end
+
+  if @nx_available do
+    @doc """
+    Convert an `Nx.Tensor` to an `ExArrow.RecordBatch`.
+
+    Supported dtypes: `{:u, 8}`, `{:s, 64}`, `{:f, 32}`, `{:f, 64}`, and
+    all other integer/float dtypes supported by `ExArrow.Schema.Mapper`.
+
+    Rank-1 tensors produce a single-column batch named `"value"`.  Rank-2
+    tensors produce an N-column batch with columns named `"c0"`, `"c1"`, ...
+    `"c{N-1}"`, where N is the size of the second axis.  Tensors of rank > 2
+    are not supported.
+
+    ## Options
+
+    - `:as` — when set to `:boolean`, the column is created as an Arrow
+      Boolean array.  Only valid for `{:u, 8}` tensors.  Default: `:numeric`.
+    - `:name` — column name for rank-1 tensors.  Default: `"value"`.
+
+    Returns `{:ok, batch}` or `{:error, message}`.
+
+    ## Examples
+
+        # Rank-1 s64 tensor
+        {:ok, batch} = ExArrow.from_nx(Nx.tensor([1, 2, 3], type: {:s, 64}))
+        ExArrow.RecordBatch.num_rows(batch)  #=> 3
+
+        # Rank-2 f64 tensor → 3 columns (c0, c1, c2), 2 rows
+        {:ok, batch} = ExArrow.from_nx(Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: {:f, 64}))
+
+        # Boolean tensor
+        {:ok, batch} = ExArrow.from_nx(Nx.tensor([1, 0, 1], type: {:u, 8}), as: :boolean)
+    """
+    @spec from_nx(Nx.Tensor.t(), keyword()) ::
+            {:ok, ExArrow.RecordBatch.t()} | {:error, String.t()}
+    def from_nx(tensor, opts \\ []) do
+      shape = Nx.shape(tensor)
+
+      cond do
+        tuple_size(shape) > 2 ->
+          {:error, "tensors of rank > 2 are not supported for Arrow conversion"}
+
+        tuple_size(shape) == 2 ->
+          from_nx_rank2(tensor)
+
+        true ->
+          name = Keyword.get(opts, :name, "value")
+          ExArrow.Nx.from_tensor(tensor, name, Keyword.take(opts, [:as]))
+      end
+    end
+
+    defp from_nx_rank2(tensor) do
+      {_rows, cols} = Nx.shape(tensor)
+      nx_dtype = Nx.type(tensor)
+
+      column_tensors =
+        for c <- 0..(cols - 1) do
+          slice = Nx.tensor(Nx.to_list(tensor[[.., c]]), type: nx_dtype)
+          {"c#{c}", slice}
+        end
+
+      ExArrow.Nx.from_tensors(Map.new(column_tensors))
+    end
+
+    @doc """
+    Convert an `ExArrow.RecordBatch` to an `Nx.Tensor`.
+
+    For a single-column numeric/boolean batch, returns a rank-1 tensor.
+    For a multi-column batch with uniform numeric dtype, returns a rank-2
+    tensor where columns become the second axis.
+
+    Returns `{:ok, tensor}` or `{:error, message}`.
+
+    ## Examples
+
+        # Single column → rank-1
+        {:ok, batch} = ExArrow.from_nx(Nx.tensor([1, 2, 3], type: {:s, 64}))
+        {:ok, tensor} = ExArrow.to_nx(batch)
+        Nx.shape(tensor)  #=> {3}
+
+        # Multi-column uniform → rank-2
+        {:ok, batch} = ExArrow.from_nx(Nx.tensor([[1, 2], [3, 4]], type: {:s, 64}))
+        {:ok, tensor} = ExArrow.to_nx(batch)
+        Nx.shape(tensor)  #=> {2, 2}
+    """
+    @spec to_nx(ExArrow.RecordBatch.t()) ::
+            {:ok, Nx.Tensor.t()} | {:error, String.t()}
+    def to_nx(batch) do
+      schema = ExArrow.RecordBatch.schema(batch)
+      fields = ExArrow.Schema.fields(schema)
+
+      case extract_numeric_fields(fields) do
+        {:error, _} = err -> err
+        {:ok, []} -> {:error, "no numeric columns available for Nx conversion"}
+        {:ok, numeric_fields} ->
+          columns = Enum.map(numeric_fields, & &1.name)
+          to_nx_from_columns(batch, columns)
+      end
+    end
+
+    defp extract_numeric_fields(fields) do
+      mapper = ExArrow.Schema.Mapper
+
+      Enum.reduce_while(fields, {:ok, []}, fn field, {:ok, acc} ->
+        case mapper.arrow_type_atom_to_dtype(field.type) do
+          {:ok, dtype} ->
+            if mapper.numeric?(dtype) do
+              {:cont, {:ok, acc ++ [field]}}
+            else
+              {:cont, {:ok, acc}}
+            end
+
+          {:error, _} ->
+            {:cont, {:ok, acc}}
+        end
+      end)
+    end
+
+    defp to_nx_from_columns(batch, [single_col]) do
+      ExArrow.Nx.column_to_tensor(batch, single_col)
+    end
+
+    defp to_nx_from_columns(batch, columns) do
+      case ExArrow.Nx.to_tensors(batch) do
+        {:ok, tensors} ->
+          col_tensors = Enum.map(columns, &Map.fetch!(tensors, &1))
+          first_dtype = Nx.type(hd(col_tensors))
+
+          if Enum.all?(col_tensors, &(Nx.type(&1) == first_dtype)) do
+            rows = Nx.size(hd(col_tensors))
+            stacked = Nx.stack(col_tensors, axis: 1)
+            {:ok, Nx.reshape(stacked, {rows, length(columns)})}
+          else
+            {:error,
+             "cannot create rank-2 tensor: columns have non-uniform dtypes. Use ExArrow.Nx.to_tensors/1 for per-column access."}
+          end
+
+        {:error, _} = err ->
+          err
+      end
+    end
+  else
+    @doc false
+    def from_nx(_tensor, _opts \\ []), do: {:error, "Nx is not available. Add {:nx, \"~> 0.9\"} to your mix.exs dependencies."}
+
+    @doc false
+    def to_nx(_batch), do: {:error, "Nx is not available. Add {:nx, \"~> 0.9\"} to your mix.exs dependencies."}
   end
 end

--- a/lib/ex_arrow.ex
+++ b/lib/ex_arrow.ex
@@ -87,7 +87,7 @@ defmodule ExArrow do
     concatenated into one batch, so the full row count and all values are
     preserved.
 
-    Schema and values are preserved.  Nullability is not guaranteed to survive
+    Schema field names and value types are preserved.  Nullability is not guaranteed to survive
     the Explorer IPC round-trip: Explorer does not distinguish nullable from
     non-nullable columns, so columns may be reported as nullable regardless of
     the source data.
@@ -108,7 +108,7 @@ defmodule ExArrow do
     Convert an `ExArrow.RecordBatch` or `ExArrow.Stream` to an
     `Explorer.DataFrame`.
 
-    Schema, row count, and values are preserved.  See `from_dataframe/1` for a
+    Column names, row count, and values are preserved.  See `from_dataframe/1` for a
     note on nullability through the Explorer round-trip.
 
     Returns `{:ok, dataframe}` or `{:error, message}`.

--- a/lib/ex_arrow.ex
+++ b/lib/ex_arrow.ex
@@ -80,10 +80,17 @@ defmodule ExArrow do
 
   if @explorer_available do
     @doc """
-    Convert an `Explorer.DataFrame` to an `ExArrow.RecordBatch`.
+    Convert an `Explorer.DataFrame` to a single `ExArrow.RecordBatch`.
 
-    The dataframe is serialised to Arrow IPC and read back as a native batch
-    handle.  Schema, nullability, row count, and values are preserved.
+    The dataframe is serialised to Arrow IPC and read back as native batches.
+    When Explorer splits a large dataframe into multiple IPC batches they are
+    concatenated into one batch, so the full row count and all values are
+    preserved.
+
+    Schema and values are preserved.  Nullability is not guaranteed to survive
+    the Explorer IPC round-trip: Explorer does not distinguish nullable from
+    non-nullable columns, so columns may be reported as nullable regardless of
+    the source data.
 
     Returns `{:ok, batch}` or `{:error, message}`.
 
@@ -101,7 +108,8 @@ defmodule ExArrow do
     Convert an `ExArrow.RecordBatch` or `ExArrow.Stream` to an
     `Explorer.DataFrame`.
 
-    Schema, nullability, row count, and values are preserved.
+    Schema, row count, and values are preserved.  See `from_dataframe/1` for a
+    note on nullability through the Explorer round-trip.
 
     Returns `{:ok, dataframe}` or `{:error, message}`.
 
@@ -116,10 +124,16 @@ defmodule ExArrow do
     def to_dataframe(batch_or_stream), do: ExArrow.DataFrame.from_arrow(batch_or_stream)
   else
     @doc false
-    def from_dataframe(_), do: {:error, "Explorer is not available. Add {:explorer, \"~> 0.11\"} to your mix.exs dependencies."}
+    def from_dataframe(_),
+      do:
+        {:error,
+         "Explorer is not available. Add {:explorer, \"~> 0.11\"} to your mix.exs dependencies."}
 
     @doc false
-    def to_dataframe(_), do: {:error, "Explorer is not available. Add {:explorer, \"~> 0.11\"} to your mix.exs dependencies."}
+    def to_dataframe(_),
+      do:
+        {:error,
+         "Explorer is not available. Add {:explorer, \"~> 0.11\"} to your mix.exs dependencies."}
   end
 
   if @nx_available do
@@ -163,6 +177,9 @@ defmodule ExArrow do
         tuple_size(shape) > 2 ->
           {:error, "tensors of rank > 2 are not supported for Arrow conversion"}
 
+        tuple_size(shape) == 2 and Keyword.get(opts, :as) == :boolean ->
+          {:error, "as: :boolean is not supported for rank-2 tensors"}
+
         tuple_size(shape) == 2 ->
           from_nx_rank2(tensor)
 
@@ -172,17 +189,22 @@ defmodule ExArrow do
       end
     end
 
+    # Column names are zero-padded (c00, c01, ...) so that the lexicographic
+    # ordering used by ExArrow.Nx.from_tensors/1 matches the numeric column
+    # order.  Without padding, "c10" would sort before "c2" and corrupt the
+    # column order for tensors with more than 10 columns.
     defp from_nx_rank2(tensor) do
       {_rows, cols} = Nx.shape(tensor)
       nx_dtype = Nx.type(tensor)
+      width = cols |> Integer.to_string() |> String.length()
 
       column_tensors =
-        for c <- 0..(cols - 1) do
-          slice = Nx.tensor(Nx.to_list(tensor[[.., c]]), type: nx_dtype)
-          {"c#{c}", slice}
+        for c <- 0..(cols - 1), into: %{} do
+          name = "c" <> String.pad_leading(Integer.to_string(c), width, "0")
+          {name, Nx.as_type(tensor[[.., c]], nx_dtype)}
         end
 
-      ExArrow.Nx.from_tensors(Map.new(column_tensors))
+      ExArrow.Nx.from_tensors(column_tensors)
     end
 
     @doc """
@@ -213,10 +235,19 @@ defmodule ExArrow do
       fields = ExArrow.Schema.fields(schema)
 
       case extract_numeric_fields(fields) do
-        {:error, _} = err -> err
-        {:ok, []} -> {:error, "no numeric columns available for Nx conversion"}
+        {:error, _} = err ->
+          err
+
+        {:ok, []} ->
+          {:error, "no numeric columns available for Nx conversion"}
+
         {:ok, numeric_fields} ->
-          columns = Enum.map(numeric_fields, & &1.name)
+          # Sort by column name so multi-column reconstruction is deterministic
+          # and independent of the batch's internal field order (which is not
+          # guaranteed for batches built from a map of tensors).  `from_nx/1`
+          # zero-pads rank-2 column names (c00, c01, ...) so that this
+          # lexicographic sort matches the original numeric column order.
+          columns = numeric_fields |> Enum.map(& &1.name) |> Enum.sort()
           to_nx_from_columns(batch, columns)
       end
     end
@@ -224,19 +255,25 @@ defmodule ExArrow do
     defp extract_numeric_fields(fields) do
       mapper = ExArrow.Schema.Mapper
 
-      Enum.reduce_while(fields, {:ok, []}, fn field, {:ok, acc} ->
-        case mapper.arrow_type_atom_to_dtype(field.type) do
-          {:ok, dtype} ->
-            if mapper.numeric?(dtype) do
-              {:cont, {:ok, acc ++ [field]}}
-            else
-              {:cont, {:ok, acc}}
-            end
+      result =
+        Enum.reduce_while(fields, {:ok, []}, fn field, {:ok, acc} ->
+          case mapper.arrow_type_atom_to_dtype(field.type) do
+            {:ok, dtype} ->
+              if mapper.numeric?(dtype) do
+                {:cont, {:ok, [field | acc]}}
+              else
+                {:cont, {:ok, acc}}
+              end
 
-          {:error, _} ->
-            {:cont, {:ok, acc}}
-        end
-      end)
+            {:error, _} ->
+              {:cont, {:ok, acc}}
+          end
+        end)
+
+      case result do
+        {:ok, fields} -> {:ok, Enum.reverse(fields)}
+        other -> other
+      end
     end
 
     defp to_nx_from_columns(batch, [single_col]) do
@@ -264,9 +301,11 @@ defmodule ExArrow do
     end
   else
     @doc false
-    def from_nx(_tensor, _opts \\ []), do: {:error, "Nx is not available. Add {:nx, \"~> 0.9\"} to your mix.exs dependencies."}
+    def from_nx(_tensor, _opts \\ []),
+      do: {:error, "Nx is not available. Add {:nx, \"~> 0.9\"} to your mix.exs dependencies."}
 
     @doc false
-    def to_nx(_batch), do: {:error, "Nx is not available. Add {:nx, \"~> 0.9\"} to your mix.exs dependencies."}
+    def to_nx(_batch),
+      do: {:error, "Nx is not available. Add {:nx, \"~> 0.9\"} to your mix.exs dependencies."}
   end
 end

--- a/lib/ex_arrow/array.ex
+++ b/lib/ex_arrow/array.ex
@@ -2,8 +2,27 @@ defmodule ExArrow.Array do
   @moduledoc """
   Arrow array handle (opaque reference to native array).
 
-  Column data lives in native memory. This module provides a stable handle;
-  copying to the BEAM heap is done only when explicitly requested (future API).
+  An Array is the leaf node of the Arrow hierarchy — a single column of typed,
+  contiguous values.  Arrays are grouped into `ExArrow.RecordBatch` instances
+  (one array per column), and batches are streamed via `ExArrow.Stream`.
+
+  Data lives in native (Rust) memory.  This module provides a stable handle;
+  copying to the BEAM heap is done only when explicitly requested through
+  bridge modules such as `ExArrow.Nx.column_to_tensor/2`.
+
+  ## Position in the hierarchy
+
+      Schema ── Field (metadata: name, type, nullable)
+                  │
+      RecordBatch ── Array (one per column, shared row count)
+                        │
+      Table ── RecordBatch (one or more batches, shared schema)
+                        │
+      Stream ── RecordBatch (lazy sequence)
+
+  The Array handle itself is currently opaque on the Elixir side.  Inspection
+  functions (length, data type, null count) will be added as the NIF layer
+  gains the corresponding entry points.
   """
   @opaque t :: %__MODULE__{resource: reference()}
   defstruct [:resource]

--- a/lib/ex_arrow/data_frame.ex
+++ b/lib/ex_arrow/data_frame.ex
@@ -1,0 +1,102 @@
+defmodule ExArrow.DataFrame do
+  @moduledoc """
+  Ergonomic conversion between Explorer DataFrames and Arrow data.
+
+  This module provides the `from_arrow/1` and `to_arrow/1` API requested by
+  users who think in DataFrame-first terms.  It delegates to
+  `ExArrow.Explorer` for the actual IPC round-trip.
+
+  Requires `{:explorer, "~> 0.11"}` in your `mix.exs` dependencies.  When
+  Explorer is absent every function returns `{:error, "Explorer is not
+  available..."}`.
+
+  ## Arrow hierarchy
+
+  An Arrow `RecordBatch` is a collection of column arrays with a shared schema
+  and row count.  A `Stream` is a sequence of batches.  Both carry the same
+  columnar data; `from_arrow/1` accepts either.
+
+  ## Examples
+
+      # DataFrame → Arrow
+      df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+      {:ok, batch} = ExArrow.DataFrame.to_arrow(df)
+
+      # Arrow → DataFrame
+      {:ok, df2} = ExArrow.DataFrame.from_arrow(batch)
+      Explorer.DataFrame.n_rows(df2)  #=> 3
+  """
+
+  alias ExArrow.Explorer, as: ExArrowExplorer
+  alias ExArrow.RecordBatch
+  alias ExArrow.Stream
+
+  @explorer_available Code.ensure_loaded?(Explorer.DataFrame)
+
+  if @explorer_available do
+    @doc """
+    Convert Arrow data to an `Explorer.DataFrame`.
+
+    Accepts either an `ExArrow.RecordBatch` or an `ExArrow.Stream`.  Streams
+    are consumed entirely (all batches collected) before conversion.
+
+    Returns `{:ok, dataframe}` or `{:error, message}`.
+
+    ## Examples
+
+        {:ok, stream} = ExArrow.IPC.Reader.from_file("/data/events.arrow")
+        {:ok, df} = ExArrow.DataFrame.from_arrow(stream)
+        Explorer.DataFrame.n_rows(df)  #=> 1_000_000
+
+        {:ok, batch} = ExArrow.DataFrame.to_arrow(df)
+        {:ok, df2}   = ExArrow.DataFrame.from_arrow(batch)
+        Explorer.DataFrame.names(df2)  #=> ["x", "y"]
+    """
+    @spec from_arrow(RecordBatch.t() | Stream.t()) ::
+            {:ok, Explorer.DataFrame.t()} | {:error, String.t()}
+    def from_arrow(%Stream{} = stream) do
+      ExArrowExplorer.from_stream(stream)
+    end
+
+    def from_arrow(%RecordBatch{} = batch) do
+      ExArrowExplorer.from_record_batch(batch)
+    end
+
+    @doc """
+    Convert an `Explorer.DataFrame` to an `ExArrow.RecordBatch`.
+
+    The dataframe is serialised to Arrow IPC via
+    `Explorer.DataFrame.dump_ipc_stream!/1`, then read back as a native Arrow
+    batch handle.  For dataframes that produce multiple batches in the IPC
+    representation, the first batch is returned (the common case for
+    in-memory data is a single batch).
+
+    Returns `{:ok, batch}` or `{:error, message}`.
+
+    ## Examples
+
+        df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+        {:ok, batch} = ExArrow.DataFrame.to_arrow(df)
+        ExArrow.RecordBatch.num_rows(batch)  #=> 3
+    """
+    @spec to_arrow(Explorer.DataFrame.t()) ::
+            {:ok, RecordBatch.t()} | {:error, String.t()}
+    def to_arrow(df) do
+      case ExArrowExplorer.to_record_batches(df) do
+        {:ok, [batch | _]} -> {:ok, batch}
+        {:ok, []} -> {:error, "no batches produced from dataframe"}
+        {:error, _} = err -> err
+      end
+    end
+  else
+    @doc false
+    def from_arrow(_), do: {:error, explorer_missing_message()}
+
+    @doc false
+    def to_arrow(_), do: {:error, explorer_missing_message()}
+
+    defp explorer_missing_message do
+      "Explorer is not available. Add {:explorer, \"~> 0.11\"} to your mix.exs dependencies."
+    end
+  end
+end

--- a/lib/ex_arrow/data_frame.ex
+++ b/lib/ex_arrow/data_frame.ex
@@ -54,14 +54,17 @@ defmodule ExArrow.DataFrame do
     """
     @spec from_arrow(RecordBatch.t() | Stream.t()) ::
             {:ok, Explorer.DataFrame.t()} | {:error, String.t()}
-    # dialyzer: pattern matching on opaque structs is intentional here —
-    # we dispatch to the correct bridge function based on the struct type.
-    def from_arrow(%Stream{} = stream) do
-      ExArrowExplorer.from_stream(stream)
-    end
+    def from_arrow(arg) do
+      cond do
+        RecordBatch.record_batch?(arg) ->
+          ExArrowExplorer.from_record_batch(arg)
 
-    def from_arrow(%RecordBatch{} = batch) do
-      ExArrowExplorer.from_record_batch(batch)
+        Stream.stream?(arg) ->
+          ExArrowExplorer.from_stream(arg)
+
+        true ->
+          {:error, "expected an ExArrow.RecordBatch or ExArrow.Stream, got: #{inspect(arg)}"}
+      end
     end
 
     @doc """

--- a/lib/ex_arrow/data_frame.ex
+++ b/lib/ex_arrow/data_frame.ex
@@ -54,6 +54,8 @@ defmodule ExArrow.DataFrame do
     """
     @spec from_arrow(RecordBatch.t() | Stream.t()) ::
             {:ok, Explorer.DataFrame.t()} | {:error, String.t()}
+    # dialyzer: pattern matching on opaque structs is intentional here —
+    # we dispatch to the correct bridge function based on the struct type.
     def from_arrow(%Stream{} = stream) do
       ExArrowExplorer.from_stream(stream)
     end
@@ -63,13 +65,13 @@ defmodule ExArrow.DataFrame do
     end
 
     @doc """
-    Convert an `Explorer.DataFrame` to an `ExArrow.RecordBatch`.
+    Convert an `Explorer.DataFrame` to a single `ExArrow.RecordBatch`.
 
     The dataframe is serialised to Arrow IPC via
-    `Explorer.DataFrame.dump_ipc_stream!/1`, then read back as a native Arrow
-    batch handle.  For dataframes that produce multiple batches in the IPC
-    representation, the first batch is returned (the common case for
-    in-memory data is a single batch).
+    `Explorer.DataFrame.dump_ipc_stream!/1`, then read back as native Arrow
+    batches.  Explorer may split a large dataframe into multiple IPC batches;
+    these are concatenated into a single `RecordBatch` so that the full row
+    count and all values are preserved.
 
     Returns `{:ok, batch}` or `{:error, message}`.
 
@@ -83,9 +85,19 @@ defmodule ExArrow.DataFrame do
             {:ok, RecordBatch.t()} | {:error, String.t()}
     def to_arrow(df) do
       case ExArrowExplorer.to_record_batches(df) do
-        {:ok, [batch | _]} -> {:ok, batch}
         {:ok, []} -> {:error, "no batches produced from dataframe"}
+        {:ok, [batch]} -> {:ok, batch}
+        {:ok, batches} -> concat_batches(batches)
         {:error, _} = err -> err
+      end
+    end
+
+    defp concat_batches(batches) do
+      refs = Enum.map(batches, &RecordBatch.resource_ref/1)
+
+      case ExArrow.Native.record_batch_concat(refs) do
+        {:ok, ref} -> {:ok, RecordBatch.from_ref(ref)}
+        {:error, msg} -> {:error, msg}
       end
     end
   else

--- a/lib/ex_arrow/data_frame.ex
+++ b/lib/ex_arrow/data_frame.ex
@@ -33,6 +33,12 @@ defmodule ExArrow.DataFrame do
 
   @explorer_available Code.ensure_loaded?(Explorer.DataFrame)
 
+  # Test-only injection point without global config: each ExUnit test runs in its
+  # own process, so using the process dictionary avoids cross-test interference.
+  defp explorer_impl do
+    Process.get({__MODULE__, :explorer_impl}, ExArrowExplorer)
+  end
+
   if @explorer_available do
     @doc """
     Convert Arrow data to an `Explorer.DataFrame`.
@@ -57,10 +63,10 @@ defmodule ExArrow.DataFrame do
     def from_arrow(arg) do
       cond do
         RecordBatch.record_batch?(arg) ->
-          ExArrowExplorer.from_record_batch(arg)
+          explorer_impl().from_record_batch(arg)
 
         Stream.stream?(arg) ->
-          ExArrowExplorer.from_stream(arg)
+          explorer_impl().from_stream(arg)
 
         true ->
           {:error, "expected an ExArrow.RecordBatch or ExArrow.Stream, got: #{inspect(arg)}"}
@@ -87,7 +93,7 @@ defmodule ExArrow.DataFrame do
     @spec to_arrow(Explorer.DataFrame.t()) ::
             {:ok, RecordBatch.t()} | {:error, String.t()}
     def to_arrow(df) do
-      case ExArrowExplorer.to_record_batches(df) do
+      case explorer_impl().to_record_batches(df) do
         {:ok, []} -> {:error, "no batches produced from dataframe"}
         {:ok, [batch]} -> {:ok, batch}
         {:ok, batches} -> concat_batches(batches)

--- a/lib/ex_arrow/field.ex
+++ b/lib/ex_arrow/field.ex
@@ -1,16 +1,22 @@
 defmodule ExArrow.Field do
   @moduledoc """
-  Arrow field metadata (name and type).
+  Arrow field metadata (name, type, and nullability).
 
-  Elixir-friendly struct returned from schema/record-batch metadata.
+  Elixir-friendly struct returned from schema/record-batch metadata.  A field
+  corresponds to one column in a record batch.  The `nullable` flag indicates
+  whether the column can contain null values; it defaults to `true` (Arrow's
+  default for fields without an explicit nullability marker).
   """
+
   @type t :: %__MODULE__{
           name: String.t(),
-          type: term()
+          type: term(),
+          nullable: boolean()
         }
-  defstruct [:name, :type]
+
+  defstruct [:name, :type, nullable: true]
 
   @doc false
-  @spec new(String.t(), term()) :: t()
-  def new(name, type), do: %__MODULE__{name: name, type: type}
+  @spec new(String.t(), term(), boolean()) :: t()
+  def new(name, type, nullable \\ true), do: %__MODULE__{name: name, type: type, nullable: nullable}
 end

--- a/lib/ex_arrow/field.ex
+++ b/lib/ex_arrow/field.ex
@@ -18,5 +18,6 @@ defmodule ExArrow.Field do
 
   @doc false
   @spec new(String.t(), term(), boolean()) :: t()
-  def new(name, type, nullable \\ true), do: %__MODULE__{name: name, type: type, nullable: nullable}
+  def new(name, type, nullable \\ true),
+    do: %__MODULE__{name: name, type: type, nullable: nullable}
 end

--- a/lib/ex_arrow/native.ex
+++ b/lib/ex_arrow/native.ex
@@ -130,6 +130,8 @@ defmodule ExArrow.Native do
   def record_batch_from_column_binaries(_names, _binaries, _dtypes, _length),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  def record_batch_concat(_batches), do: :erlang.nif_error(:nif_not_loaded)
+
   # Compute kernels
   def compute_filter(_batch_ref, _predicate_ref), do: :erlang.nif_error(:nif_not_loaded)
   def compute_project(_batch_ref, _column_names), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/ex_arrow/nx.ex
+++ b/lib/ex_arrow/nx.ex
@@ -37,12 +37,15 @@ defmodule ExArrow.Nx do
 
   ### Null handling
 
-  Arrow null positions are treated as zero bytes in the extracted buffer.  For
-  numeric columns the null bitmap is irrelevant because the backing buffer holds
-  unspecified bytes at null positions; for Boolean columns the NIF now checks
-  the null bitmap explicitly and writes 0 for null slots.  If you need to
-  distinguish nulls from real zero values, inspect the original batch (full null
-  support may be added in a future release).
+  Arrow validity (null) bitmaps are not exposed through this API.
+
+  For numeric columns, null slots have unspecified backing bytes in Arrow
+  memory, so the extracted buffer is not meaningful at null positions.
+  For Boolean columns, ExArrow explicitly checks the null bitmap and emits 0 for
+  null slots.
+
+  If you need to distinguish nulls from real zero values, inspect the original
+  batch (full null support may be added in a future release).
 
   ## Public API
 
@@ -50,7 +53,7 @@ defmodule ExArrow.Nx do
   |----------|-----------|-------------|
   | `column_to_tensor/2` | Arrow → Nx | Extract one named numeric/boolean column as an `Nx.Tensor` |
   | `to_tensors/1` | Arrow → Nx | Extract all numeric/boolean columns as `%{name => Nx.Tensor}` |
-  | `from_tensor/2` | Nx → Arrow | Single tensor → single-column `RecordBatch` |
+  | `from_tensor/3` | Nx → Arrow | Single tensor → single-column `RecordBatch` |
   | `from_tensors/1` | Nx → Arrow | Map of tensors → multi-column `RecordBatch` (single NIF call) |
 
   ## Quick example
@@ -240,8 +243,8 @@ defmodule ExArrow.Nx do
     All tensors must have the same number of elements (`Nx.size/1`).  For
     rank-2 or higher-rank tensors the elements are flattened into a 1-D column.
 
-    Column order in the resulting batch follows `Map.to_list/1` ordering (i.e.
-    sorted by key).  Supported dtypes are the same as `from_tensor/2`.
+    Column order in the resulting batch is deterministic: columns are sorted
+    lexicographically by name. Supported dtypes are the same as `from_tensor/3`.
 
     Returns `{:ok, batch}` or `{:error, message}`.
 
@@ -265,7 +268,17 @@ defmodule ExArrow.Nx do
     @spec from_tensors(%{String.t() => Nx.Tensor.t()}) ::
             {:ok, RecordBatch.t()} | {:error, String.t()}
     def from_tensors(tensors) when is_map(tensors) do
-      case collect_tensor_columns(Map.to_list(tensors)) do
+      entries = Map.to_list(tensors)
+
+      # Maps do not guarantee iteration order; sort for deterministic schema order.
+      entries =
+        if Enum.all?(entries, fn {name, _tensor} -> is_binary(name) end) do
+          Enum.sort_by(entries, fn {name, _tensor} -> name end)
+        else
+          entries
+        end
+
+      case collect_tensor_columns(entries) do
         {:error, _} = err ->
           err
 

--- a/lib/ex_arrow/nx.ex
+++ b/lib/ex_arrow/nx.ex
@@ -2,10 +2,10 @@ defmodule ExArrow.Nx do
   @moduledoc """
   Bridge between ExArrow and Nx tensors.
 
-  Converts numeric Arrow columns to `Nx.Tensor` values (and back) by copying
-  the raw byte buffer once from native Arrow memory into an Elixir binary, then
-  handing it directly to `Nx.from_binary/2`.  No intermediate list
-  materialisation occurs.
+  Converts numeric and boolean Arrow columns to `Nx.Tensor` values (and back)
+  by copying the raw byte buffer once from native Arrow memory into an Elixir
+  binary, then handing it directly to `Nx.from_binary/2`.  No intermediate
+  list materialisation occurs.
 
   Requires `{:nx, "~> 0.9"}` in your `mix.exs` dependencies.  When Nx is
   absent every function returns `{:error, "Nx is not available..."}`.
@@ -24,10 +24,16 @@ defmodule ExArrow.Nx do
   | UInt64            | `{:u, 64}`   |
   | Float32           | `{:f, 32}`   |
   | Float64           | `{:f, 64}`   |
+  | Boolean           | `{:u, 8}`    |
 
-  Columns of other types (Utf8, Boolean, Timestamp, …) are not supported for
-  direct buffer extraction and return `{:error, "unsupported column type…"}`.
-  `to_tensors/1` silently skips non-numeric columns.
+  Arrow Boolean columns are materialised as one byte per element (0 or 1) and
+  converted to an `{:u, 8}` Nx tensor.  The reverse path accepts `{:u, 8}`
+  tensors and builds an Arrow Boolean column when the `as: :boolean` option is
+  passed to `from_tensor/3`.
+
+  Columns of other types (Utf8, Timestamp, etc.) are not supported for direct
+  buffer extraction and return `{:error, "unsupported column type..."}`.
+  `to_tensors/1` silently skips unsupported columns.
 
   ### Null handling
 
@@ -39,8 +45,8 @@ defmodule ExArrow.Nx do
 
   | Function | Direction | Description |
   |----------|-----------|-------------|
-  | `column_to_tensor/2` | Arrow → Nx | Extract one named numeric column as an `Nx.Tensor` |
-  | `to_tensors/1` | Arrow → Nx | Extract all numeric columns as `%{name => Nx.Tensor}` |
+  | `column_to_tensor/2` | Arrow → Nx | Extract one named numeric/boolean column as an `Nx.Tensor` |
+  | `to_tensors/1` | Arrow → Nx | Extract all numeric/boolean columns as `%{name => Nx.Tensor}` |
   | `from_tensor/2` | Nx → Arrow | Single tensor → single-column `RecordBatch` |
   | `from_tensors/1` | Nx → Arrow | Map of tensors → multi-column `RecordBatch` (single NIF call) |
 
@@ -63,16 +69,20 @@ defmodule ExArrow.Nx do
   alias ExArrow.Native
   alias ExArrow.RecordBatch
   alias ExArrow.Schema
+  alias ExArrow.Schema.Mapper
 
   @nx_available Code.ensure_loaded?(Nx)
 
   if @nx_available do
     @doc """
-    Convert a named numeric column from `batch` to an `Nx.Tensor`.
+    Convert a named numeric or boolean column from `batch` to an `Nx.Tensor`.
 
     The column's raw byte buffer is copied once from native Arrow memory into an
     Elixir binary, then passed to `Nx.from_binary/2`.  No list materialisation
     occurs.
+
+    Boolean columns are extracted as one byte per element (0 or 1) and returned
+    as an `{:u, 8}` tensor.
 
     Returns `{:ok, tensor}` or `{:error, message}`.
 
@@ -86,6 +96,10 @@ defmodule ExArrow.Nx do
         # Extract a float64 column and compute the mean
         {:ok, prices} = ExArrow.Nx.column_to_tensor(batch, "price")
         Nx.mean(prices) |> Nx.to_number()
+
+        # Extract a boolean column
+        {:ok, flags} = ExArrow.Nx.column_to_tensor(batch, "active")
+        Nx.type(flags)  #=> {:u, 8}
 
         # Non-numeric column returns an error
         {:error, msg} = ExArrow.Nx.column_to_tensor(batch, "name")
@@ -101,7 +115,7 @@ defmodule ExArrow.Nx do
 
       case Native.record_batch_column_buffer(ref, col_name) do
         {:ok, {binary, dtype_str, _length}} ->
-          case parse_nx_dtype(dtype_str) do
+          case Mapper.arrow_dtype_to_nx(dtype_str) do
             {:ok, nx_dtype} -> {:ok, Nx.from_binary(binary, nx_dtype)}
             {:error, msg} -> {:error, msg}
           end
@@ -112,9 +126,10 @@ defmodule ExArrow.Nx do
     end
 
     @doc """
-    Convert all numeric columns from `batch` to a map of `Nx.Tensor` values.
+    Convert all numeric and boolean columns from `batch` to a map of
+    `Nx.Tensor` values.
 
-    Non-numeric columns (Utf8, Boolean, Timestamp, etc.) are silently skipped.
+    Non-numeric columns (Utf8, Timestamp, etc.) are silently skipped.
 
     Returns `{:ok, %{column_name => tensor}}` or `{:error, message}`.
 
@@ -123,7 +138,7 @@ defmodule ExArrow.Nx do
         {:ok, tensors} = ExArrow.Nx.to_tensors(batch)
         # tensors is a map: %{"price" => #Nx.Tensor<...>, "qty" => #Nx.Tensor<...>}
         tensors["price"] |> Nx.sort()
-        Map.keys(tensors)  # only numeric columns are present
+        Map.keys(tensors)  # only numeric/boolean columns are present
     """
     @spec to_tensors(RecordBatch.t()) ::
             {:ok, %{String.t() => Nx.Tensor.t()}} | {:error, String.t()}
@@ -136,7 +151,7 @@ defmodule ExArrow.Nx do
           {:ok, tensor} ->
             {:cont, {:ok, Map.put(acc, field.name, tensor)}}
 
-          {:error, "unsupported column type" <> _} ->
+          {:error, "unsupported" <> _} ->
             {:cont, {:ok, acc}}
 
           {:error, msg} ->
@@ -154,7 +169,12 @@ defmodule ExArrow.Nx do
 
     Supported Nx dtypes: `{:s, 8|16|32|64}`, `{:u, 8|16|32|64}`,
     `{:f, 32|64}`.  Other dtypes (e.g. `{:bf, 16}`, `{:c, 64}`) return
-    `{:error, "unsupported Nx dtype…"}`.
+    `{:error, "unsupported Nx dtype..."}`.
+
+    ## Options
+
+    - `:as` — when set to `:boolean`, the column is created as an Arrow Boolean
+      array instead of UInt8.  Only valid when the tensor dtype is `{:u, 8}`.
 
     Returns `{:ok, batch}` or `{:error, message}`.
 
@@ -171,25 +191,42 @@ defmodule ExArrow.Nx do
         {:ok, recovered} = ExArrow.Nx.column_to_tensor(batch, "vals")
         Nx.to_list(recovered)  #=> [10, 20, 30]
 
+        # Boolean tensor → Arrow Boolean column
+        flags = Nx.tensor([1, 0, 1], type: {:u, 8})
+        {:ok, batch} = ExArrow.Nx.from_tensor(flags, "active", as: :boolean)
+
         # Unsupported dtype
         {:error, msg} = ExArrow.Nx.from_tensor(Nx.tensor([1, 2], type: {:bf, 16}), "x")
     """
-    @spec from_tensor(Nx.Tensor.t(), String.t()) ::
+    @spec from_tensor(Nx.Tensor.t(), String.t(), keyword()) ::
             {:ok, RecordBatch.t()} | {:error, String.t()}
-    def from_tensor(tensor, col_name) when is_binary(col_name) do
+    def from_tensor(tensor, col_name, opts \\ []) when is_binary(col_name) do
       nx_dtype = Nx.type(tensor)
       binary = Nx.to_binary(tensor)
       length = Nx.size(tensor)
+      as = Keyword.get(opts, :as, :numeric)
 
-      case nx_dtype_to_arrow(nx_dtype) do
-        {:ok, dtype_str} ->
-          case Native.record_batch_from_column_binary(col_name, binary, dtype_str, length) do
+      cond do
+        as == :boolean and nx_dtype != {:u, 8} ->
+          {:error, "as: :boolean is only valid for {:u, 8} tensors, got: #{inspect(nx_dtype)}"}
+
+        as == :boolean ->
+          case Native.record_batch_from_column_binary(col_name, binary, "bool", length) do
             {:ok, ref} -> {:ok, RecordBatch.from_ref(ref)}
             {:error, msg} -> {:error, msg}
           end
 
-        {:error, msg} ->
-          {:error, msg}
+        true ->
+          case Mapper.nx_dtype_to_arrow(nx_dtype) do
+            {:ok, dtype_str} ->
+              case Native.record_batch_from_column_binary(col_name, binary, dtype_str, length) do
+                {:ok, ref} -> {:ok, RecordBatch.from_ref(ref)}
+                {:error, msg} -> {:error, msg}
+              end
+
+            {:error, msg} ->
+              {:error, msg}
+          end
       end
     end
 
@@ -246,7 +283,7 @@ defmodule ExArrow.Nx do
 
     defp collect_one_column(name, tensor, ns, ds, bs, ls) do
       if is_binary(name) do
-        case nx_dtype_to_arrow(Nx.type(tensor)) do
+        case Mapper.nx_dtype_to_arrow(Nx.type(tensor)) do
           {:ok, dtype_str} ->
             {:cont,
              {:ok, [name | ns], [dtype_str | ds], [Nx.to_binary(tensor) | bs],
@@ -280,34 +317,6 @@ defmodule ExArrow.Nx do
         end
       end
     end
-
-    # ── dtype helpers ────────────────────────────────────────────────────────
-
-    defp parse_nx_dtype("s8"), do: {:ok, {:s, 8}}
-    defp parse_nx_dtype("s16"), do: {:ok, {:s, 16}}
-    defp parse_nx_dtype("s32"), do: {:ok, {:s, 32}}
-    defp parse_nx_dtype("s64"), do: {:ok, {:s, 64}}
-    defp parse_nx_dtype("u8"), do: {:ok, {:u, 8}}
-    defp parse_nx_dtype("u16"), do: {:ok, {:u, 16}}
-    defp parse_nx_dtype("u32"), do: {:ok, {:u, 32}}
-    defp parse_nx_dtype("u64"), do: {:ok, {:u, 64}}
-    defp parse_nx_dtype("f32"), do: {:ok, {:f, 32}}
-    defp parse_nx_dtype("f64"), do: {:ok, {:f, 64}}
-    defp parse_nx_dtype(other), do: {:error, "unknown Arrow dtype string: #{other}"}
-
-    defp nx_dtype_to_arrow({:s, 8}), do: {:ok, "s8"}
-    defp nx_dtype_to_arrow({:s, 16}), do: {:ok, "s16"}
-    defp nx_dtype_to_arrow({:s, 32}), do: {:ok, "s32"}
-    defp nx_dtype_to_arrow({:s, 64}), do: {:ok, "s64"}
-    defp nx_dtype_to_arrow({:u, 8}), do: {:ok, "u8"}
-    defp nx_dtype_to_arrow({:u, 16}), do: {:ok, "u16"}
-    defp nx_dtype_to_arrow({:u, 32}), do: {:ok, "u32"}
-    defp nx_dtype_to_arrow({:u, 64}), do: {:ok, "u64"}
-    defp nx_dtype_to_arrow({:f, 32}), do: {:ok, "f32"}
-    defp nx_dtype_to_arrow({:f, 64}), do: {:ok, "f64"}
-
-    defp nx_dtype_to_arrow(dt),
-      do: {:error, "unsupported Nx dtype for Arrow conversion: #{inspect(dt)}"}
   else
     @doc false
     def column_to_tensor(_batch, _col_name), do: {:error, nx_missing_message()}
@@ -316,7 +325,7 @@ defmodule ExArrow.Nx do
     def to_tensors(_batch), do: {:error, nx_missing_message()}
 
     @doc false
-    def from_tensor(_tensor, _col_name), do: {:error, nx_missing_message()}
+    def from_tensor(_tensor, _col_name, _opts \\ []), do: {:error, nx_missing_message()}
 
     @doc false
     def from_tensors(_tensors), do: {:error, nx_missing_message()}

--- a/lib/ex_arrow/nx.ex
+++ b/lib/ex_arrow/nx.ex
@@ -37,9 +37,12 @@ defmodule ExArrow.Nx do
 
   ### Null handling
 
-  Arrow null positions are treated as zero bytes in the extracted buffer.  If
-  your column contains nulls and you need to distinguish them, inspect the
-  original batch (null support may be added in a future release).
+  Arrow null positions are treated as zero bytes in the extracted buffer.  For
+  numeric columns the null bitmap is irrelevant because the backing buffer holds
+  unspecified bytes at null positions; for Boolean columns the NIF now checks
+  the null bitmap explicitly and writes 0 for null slots.  If you need to
+  distinguish nulls from real zero values, inspect the original batch (full null
+  support may be added in a future release).
 
   ## Public API
 

--- a/lib/ex_arrow/record_batch.ex
+++ b/lib/ex_arrow/record_batch.ex
@@ -22,6 +22,11 @@ defmodule ExArrow.RecordBatch do
   defstruct [:resource]
 
   @doc false
+  @spec record_batch?(term()) :: boolean()
+  def record_batch?(%__MODULE__{}), do: true
+  def record_batch?(_), do: false
+
+  @doc false
   @spec from_ref(reference()) :: t()
   def from_ref(ref), do: %__MODULE__{resource: ref}
 

--- a/lib/ex_arrow/record_batch.ex
+++ b/lib/ex_arrow/record_batch.ex
@@ -2,8 +2,18 @@ defmodule ExArrow.RecordBatch do
   @moduledoc """
   Arrow record batch handle (opaque reference to native record batch).
 
-  A batch is a collection of arrays (columns) with a shared row count.
-  Data stays in native memory; accessors return handles or small metadata.
+  A batch is a collection of column arrays with a shared schema and row count.
+  It sits between `ExArrow.Array` (one column) and `ExArrow.Table` / 
+  `ExArrow.Stream` (multiple batches).  Data stays in native memory; accessors
+  return handles or small metadata.
+
+  ## Position in the hierarchy
+
+      Schema ── Field (metadata)
+                  │
+      RecordBatch ── Array (one per column)
+                        │
+      Table / Stream ── RecordBatch (one or more)
   """
   alias ExArrow.Native
   alias ExArrow.Schema
@@ -33,5 +43,40 @@ defmodule ExArrow.RecordBatch do
   @spec num_rows(t()) :: non_neg_integer()
   def num_rows(%__MODULE__{resource: ref}) do
     Native.record_batch_num_rows(ref)
+  end
+
+  @doc """
+  Returns the number of columns in this batch.
+
+  Derived from the batch's schema — no separate NIF call is needed.
+
+  ## Examples
+
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream}  = ExArrow.IPC.Reader.from_binary(ipc_bin)
+      batch = ExArrow.Stream.next(stream)
+      ExArrow.RecordBatch.num_columns(batch)  #=> 2
+  """
+  @spec num_columns(t()) :: non_neg_integer()
+  def num_columns(%__MODULE__{} = batch) do
+    batch |> schema() |> Schema.fields() |> length()
+  end
+
+  @doc """
+  Returns the column names of this batch.
+
+  Derived from the batch's schema.  Equivalent to
+  `ExArrow.Schema.field_names(ExArrow.RecordBatch.schema(batch))`.
+
+  ## Examples
+
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream}  = ExArrow.IPC.Reader.from_binary(ipc_bin)
+      batch = ExArrow.Stream.next(stream)
+      ExArrow.RecordBatch.column_names(batch)  #=> ["id", "name"]
+  """
+  @spec column_names(t()) :: [String.t()]
+  def column_names(%__MODULE__{} = batch) do
+    batch |> schema() |> Schema.field_names()
   end
 end

--- a/lib/ex_arrow/record_batch.ex
+++ b/lib/ex_arrow/record_batch.ex
@@ -3,7 +3,7 @@ defmodule ExArrow.RecordBatch do
   Arrow record batch handle (opaque reference to native record batch).
 
   A batch is a collection of column arrays with a shared schema and row count.
-  It sits between `ExArrow.Array` (one column) and `ExArrow.Table` / 
+  It sits between `ExArrow.Array` (one column) and `ExArrow.Table` or 
   `ExArrow.Stream` (multiple batches).  Data stays in native memory; accessors
   return handles or small metadata.
 

--- a/lib/ex_arrow/schema.ex
+++ b/lib/ex_arrow/schema.ex
@@ -2,7 +2,7 @@ defmodule ExArrow.Schema do
   @moduledoc """
   Arrow schema handle (opaque reference to native schema).
 
-  Holds metadata (field names and types) for a table or record batch.
+  Holds metadata (field names, types, and nullability) for a table or record batch.
   Data lives in native memory; this module provides a stable handle and
   Elixir-friendly accessors for small metadata.
   """

--- a/lib/ex_arrow/schema.ex
+++ b/lib/ex_arrow/schema.ex
@@ -29,7 +29,9 @@ defmodule ExArrow.Schema do
   def fields(%__MODULE__{resource: ref}) do
     ref
     |> Native.schema_fields()
-    |> Enum.map(fn {name, type, nullable} -> %Field{name: name, type: type, nullable: nullable} end)
+    |> Enum.map(fn {name, type, nullable} ->
+      %Field{name: name, type: type, nullable: nullable}
+    end)
   end
 
   @doc """

--- a/lib/ex_arrow/schema.ex
+++ b/lib/ex_arrow/schema.ex
@@ -22,12 +22,14 @@ defmodule ExArrow.Schema do
 
   @doc """
   Returns the list of fields in the schema (Elixir structs).
+
+  Each field includes `name`, `type`, and `nullable`.
   """
   @spec fields(t()) :: [Field.t()]
   def fields(%__MODULE__{resource: ref}) do
     ref
     |> Native.schema_fields()
-    |> Enum.map(fn {name, type} -> %Field{name: name, type: type} end)
+    |> Enum.map(fn {name, type, nullable} -> %Field{name: name, type: type, nullable: nullable} end)
   end
 
   @doc """

--- a/lib/ex_arrow/schema/mapper.ex
+++ b/lib/ex_arrow/schema/mapper.ex
@@ -38,7 +38,7 @@ defmodule ExArrow.Schema.Mapper do
   The existing targets are grouped by module section below.
   """
 
-  @type nx_dtype :: term()
+  @type nx_dtype :: {:s, 8 | 16 | 32 | 64} | {:u, 8 | 16 | 32 | 64} | {:f, 32 | 64}
   @type arrow_dtype :: String.t()
 
   @doc """

--- a/lib/ex_arrow/schema/mapper.ex
+++ b/lib/ex_arrow/schema/mapper.ex
@@ -1,0 +1,255 @@
+defmodule ExArrow.Schema.Mapper do
+  @moduledoc """
+  Bidirectional mapping between Arrow type representations and external type
+  systems.
+
+  ExArrow interacts with several Elixir libraries that have their own type
+  systems — Explorer, Nx, and in the future ExZarr and Dataset.  This module
+  is the single authority for converting between Arrow dtype strings (used by
+  the NIF layer) and each external representation, eliminating duplicated
+  mapping logic across bridge modules.
+
+  ## Arrow dtype strings
+
+  The NIF layer identifies column types with short string codes:
+
+  | Code     | Arrow type  |
+  |----------|-------------|
+  | `"s8"`   | Int8        |
+  | `"s16"`  | Int16       |
+  | `"s32"`  | Int32       |
+  | `"s64"`  | Int64       |
+  | `"u8"`   | UInt8       |
+  | `"u16"`  | UInt16      |
+  | `"u32"`  | UInt32      |
+  | `"u64"`  | UInt64      |
+  | `"f32"`  | Float32     |
+  | `"f64"`  | Float64     |
+  | `"bool"` | Boolean     |
+  | `"utf8"` | Utf8        |
+
+  These are the canonical internal representation.  All public conversion
+  functions accept and return these strings.
+
+  ## Extensibility
+
+  New external targets (e.g. ExZarr, Dataset) can be added by introducing
+  new `target_dtype_to_arrow/1` and `arrow_dtype_to_target/1` clause groups.
+  The existing targets are grouped by module section below.
+  """
+
+  @type arrow_dtype :: String.t()
+
+  @doc """
+  Convert an Nx dtype tuple to an Arrow dtype string.
+
+  Returns `{:ok, dtype_string}` or `{:error, message}`.
+
+  ## Supported Nx dtypes
+
+  | Nx dtype     | Arrow dtype |
+  |--------------|-------------|
+  | `{:s, 8}`    | `"s8"`      |
+  | `{:s, 16}`   | `"s16"`     |
+  | `{:s, 32}`   | `"s32"`     |
+  | `{:s, 64}`   | `"s64"`     |
+  | `{:u, 8}`    | `"u8"`      |
+  | `{:u, 16}`   | `"u16"`     |
+  | `{:u, 32}`   | `"u32"`     |
+  | `{:u, 64}`   | `"u64"`     |
+  | `{:f, 32}`   | `"f32"`     |
+  | `{:f, 64}`   | `"f64"`     |
+
+  Nx does not have a dedicated boolean dtype; booleans are represented as
+  `{:u, 8}` with values 0 and 1.  Arrow Boolean columns map to `{:u, 8}` via
+  `arrow_dtype_to_nx/1`.
+  """
+  @spec nx_dtype_to_arrow(Nx.dtype()) :: {:ok, arrow_dtype()} | {:error, String.t()}
+  def nx_dtype_to_arrow({:s, 8}), do: {:ok, "s8"}
+  def nx_dtype_to_arrow({:s, 16}), do: {:ok, "s16"}
+  def nx_dtype_to_arrow({:s, 32}), do: {:ok, "s32"}
+  def nx_dtype_to_arrow({:s, 64}), do: {:ok, "s64"}
+  def nx_dtype_to_arrow({:u, 8}), do: {:ok, "u8"}
+  def nx_dtype_to_arrow({:u, 16}), do: {:ok, "u16"}
+  def nx_dtype_to_arrow({:u, 32}), do: {:ok, "u32"}
+  def nx_dtype_to_arrow({:u, 64}), do: {:ok, "u64"}
+  def nx_dtype_to_arrow({:f, 32}), do: {:ok, "f32"}
+  def nx_dtype_to_arrow({:f, 64}), do: {:ok, "f64"}
+
+  def nx_dtype_to_arrow(dtype),
+    do: {:error, "unsupported Nx dtype for Arrow conversion: #{inspect(dtype)}"}
+
+  @doc """
+  Convert an Arrow dtype string to an Nx dtype tuple.
+
+  Returns `{:ok, nx_dtype}` or `{:error, message}`.
+
+  Boolean columns (`"bool"`) map to `{:u, 8}` because Nx represents booleans
+  as unsigned 8-bit integers with values 0 and 1.
+  """
+  @spec arrow_dtype_to_nx(arrow_dtype()) :: {:ok, Nx.dtype()} | {:error, String.t()}
+  def arrow_dtype_to_nx("s8"), do: {:ok, {:s, 8}}
+  def arrow_dtype_to_nx("s16"), do: {:ok, {:s, 16}}
+  def arrow_dtype_to_nx("s32"), do: {:ok, {:s, 32}}
+  def arrow_dtype_to_nx("s64"), do: {:ok, {:s, 64}}
+  def arrow_dtype_to_nx("u8"), do: {:ok, {:u, 8}}
+  def arrow_dtype_to_nx("u16"), do: {:ok, {:u, 16}}
+  def arrow_dtype_to_nx("u32"), do: {:ok, {:u, 32}}
+  def arrow_dtype_to_nx("u64"), do: {:ok, {:u, 64}}
+  def arrow_dtype_to_nx("f32"), do: {:ok, {:f, 32}}
+  def arrow_dtype_to_nx("f64"), do: {:ok, {:f, 64}}
+  def arrow_dtype_to_nx("bool"), do: {:ok, {:u, 8}}
+
+  def arrow_dtype_to_nx(dtype),
+    do: {:error, "unsupported Arrow dtype for Nx conversion: #{dtype}"}
+
+  @doc """
+  Convert an Explorer dtype atom to an Arrow dtype string.
+
+  Returns `{:ok, dtype_string}` or `{:error, message}`.
+
+  ## Supported Explorer dtypes
+
+  | Explorer dtype | Arrow dtype | Notes                          |
+  |----------------|-------------|--------------------------------|
+  | `:integer`     | `"s64"`     | Explorer stores as 64-bit int  |
+  | `:float`       | `"f64"`     | Explorer stores as 64-bit float|
+  | `:boolean`     | `"bool"`    | Arrow Boolean column           |
+  | `:string`      | `"utf8"`    | Arrow Utf8 column              |
+
+  Explorer dtypes `:date`, `:datetime`, `:duration`, and `:nil` are not yet
+  mapped and return an error.  These will be added as the NIF layer gains
+  support for the corresponding Arrow types.
+  """
+  @spec explorer_dtype_to_arrow(atom()) :: {:ok, arrow_dtype()} | {:error, String.t()}
+  def explorer_dtype_to_arrow(:integer), do: {:ok, "s64"}
+  def explorer_dtype_to_arrow(:float), do: {:ok, "f64"}
+  def explorer_dtype_to_arrow(:boolean), do: {:ok, "bool"}
+  def explorer_dtype_to_arrow(:string), do: {:ok, "utf8"}
+
+  def explorer_dtype_to_arrow(dtype),
+    do: {:error, "unsupported Explorer dtype for Arrow conversion: #{inspect(dtype)}"}
+
+  @doc """
+  Convert an Arrow dtype string to an Explorer dtype atom.
+
+  Returns `{:ok, explorer_dtype}` or `{:error, message}`.
+
+  Integer dtypes (`s8`–`s64`, `u8`–`u64`) all map to `:integer` because Explorer
+  does not distinguish integer widths in its dtype system.  Float dtypes (`f32`,
+  `f64`) map to `:float`.
+  """
+  @spec arrow_dtype_to_explorer(arrow_dtype()) :: {:ok, atom()} | {:error, String.t()}
+  def arrow_dtype_to_explorer("s8"), do: {:ok, :integer}
+  def arrow_dtype_to_explorer("s16"), do: {:ok, :integer}
+  def arrow_dtype_to_explorer("s32"), do: {:ok, :integer}
+  def arrow_dtype_to_explorer("s64"), do: {:ok, :integer}
+  def arrow_dtype_to_explorer("u8"), do: {:ok, :integer}
+  def arrow_dtype_to_explorer("u16"), do: {:ok, :integer}
+  def arrow_dtype_to_explorer("u32"), do: {:ok, :integer}
+  def arrow_dtype_to_explorer("u64"), do: {:ok, :integer}
+  def arrow_dtype_to_explorer("f32"), do: {:ok, :float}
+  def arrow_dtype_to_explorer("f64"), do: {:ok, :float}
+  def arrow_dtype_to_explorer("bool"), do: {:ok, :boolean}
+  def arrow_dtype_to_explorer("utf8"), do: {:ok, :string}
+
+  def arrow_dtype_to_explorer(dtype),
+    do: {:error, "unsupported Arrow dtype for Explorer conversion: #{dtype}"}
+
+  @doc """
+  Convert an Arrow type atom (as returned by `ExArrow.Schema.fields/1`) to an
+  Arrow dtype string.
+
+  Returns `{:ok, dtype_string}` or `{:error, message}`.
+
+  This bridges the NIF schema representation (atoms like `:int64`) to the
+  dtype strings used by column buffer NIFs (`"s64"`).
+
+  ## Examples
+
+      iex> ExArrow.Schema.Mapper.arrow_type_atom_to_dtype(:int64)
+      {:ok, "s64"}
+
+      iex> ExArrow.Schema.Mapper.arrow_type_atom_to_dtype(:boolean)
+      {:ok, "bool"}
+
+      iex> ExArrow.Schema.Mapper.arrow_type_atom_to_dtype(:timestamp)
+      {:error, "unsupported Arrow type atom for dtype mapping: timestamp"}
+  """
+  @spec arrow_type_atom_to_dtype(atom()) :: {:ok, arrow_dtype()} | {:error, String.t()}
+  def arrow_type_atom_to_dtype(:boolean), do: {:ok, "bool"}
+  def arrow_type_atom_to_dtype(:int8), do: {:ok, "s8"}
+  def arrow_type_atom_to_dtype(:int16), do: {:ok, "s16"}
+  def arrow_type_atom_to_dtype(:int32), do: {:ok, "s32"}
+  def arrow_type_atom_to_dtype(:int64), do: {:ok, "s64"}
+  def arrow_type_atom_to_dtype(:uint8), do: {:ok, "u8"}
+  def arrow_type_atom_to_dtype(:uint16), do: {:ok, "u16"}
+  def arrow_type_atom_to_dtype(:uint32), do: {:ok, "u32"}
+  def arrow_type_atom_to_dtype(:uint64), do: {:ok, "u64"}
+  def arrow_type_atom_to_dtype(:float32), do: {:ok, "f32"}
+  def arrow_type_atom_to_dtype(:float64), do: {:ok, "f64"}
+  def arrow_type_atom_to_dtype(:utf8), do: {:ok, "utf8"}
+  def arrow_type_atom_to_dtype(:large_utf8), do: {:ok, "utf8"}
+
+  def arrow_type_atom_to_dtype(atom),
+    do: {:error, "unsupported Arrow type atom for dtype mapping: #{atom}"}
+
+  @doc """
+  Convert an Arrow dtype string to an Arrow type atom.
+
+  Returns `{:ok, type_atom}` or `{:error, message}`.
+
+  ## Examples
+
+      iex> ExArrow.Schema.Mapper.arrow_dtype_to_type_atom("s64")
+      {:ok, :int64}
+
+      iex> ExArrow.Schema.Mapper.arrow_dtype_to_type_atom("bool")
+      {:ok, :boolean}
+  """
+  @spec arrow_dtype_to_type_atom(arrow_dtype()) :: {:ok, atom()} | {:error, String.t()}
+  def arrow_dtype_to_type_atom("s8"), do: {:ok, :int8}
+  def arrow_dtype_to_type_atom("s16"), do: {:ok, :int16}
+  def arrow_dtype_to_type_atom("s32"), do: {:ok, :int32}
+  def arrow_dtype_to_type_atom("s64"), do: {:ok, :int64}
+  def arrow_dtype_to_type_atom("u8"), do: {:ok, :uint8}
+  def arrow_dtype_to_type_atom("u16"), do: {:ok, :uint16}
+  def arrow_dtype_to_type_atom("u32"), do: {:ok, :uint32}
+  def arrow_dtype_to_type_atom("u64"), do: {:ok, :uint64}
+  def arrow_dtype_to_type_atom("f32"), do: {:ok, :float32}
+  def arrow_dtype_to_type_atom("f64"), do: {:ok, :float64}
+  def arrow_dtype_to_type_atom("bool"), do: {:ok, :boolean}
+  def arrow_dtype_to_type_atom("utf8"), do: {:ok, :utf8}
+
+  def arrow_dtype_to_type_atom(dtype),
+    do: {:error, "unsupported Arrow dtype for type atom conversion: #{dtype}"}
+
+  @doc """
+  Returns `true` if the given Arrow dtype string maps to a numeric Nx dtype,
+  `false` otherwise.
+
+  ## Examples
+
+      iex> ExArrow.Schema.Mapper.numeric?("s64")
+      true
+
+      iex> ExArrow.Schema.Mapper.numeric?("bool")
+      true
+
+      iex> ExArrow.Schema.Mapper.numeric?("utf8")
+      false
+  """
+  @spec numeric?(arrow_dtype()) :: boolean()
+  def numeric?("s8"), do: true
+  def numeric?("s16"), do: true
+  def numeric?("s32"), do: true
+  def numeric?("s64"), do: true
+  def numeric?("u8"), do: true
+  def numeric?("u16"), do: true
+  def numeric?("u32"), do: true
+  def numeric?("u64"), do: true
+  def numeric?("f32"), do: true
+  def numeric?("f64"), do: true
+  def numeric?("bool"), do: true
+  def numeric?(_), do: false
+end

--- a/lib/ex_arrow/schema/mapper.ex
+++ b/lib/ex_arrow/schema/mapper.ex
@@ -38,6 +38,7 @@ defmodule ExArrow.Schema.Mapper do
   The existing targets are grouped by module section below.
   """
 
+  @type nx_dtype :: term()
   @type arrow_dtype :: String.t()
 
   @doc """
@@ -64,7 +65,7 @@ defmodule ExArrow.Schema.Mapper do
   `{:u, 8}` with values 0 and 1.  Arrow Boolean columns map to `{:u, 8}` via
   `arrow_dtype_to_nx/1`.
   """
-  @spec nx_dtype_to_arrow(Nx.dtype()) :: {:ok, arrow_dtype()} | {:error, String.t()}
+  @spec nx_dtype_to_arrow(nx_dtype()) :: {:ok, arrow_dtype()} | {:error, String.t()}
   def nx_dtype_to_arrow({:s, 8}), do: {:ok, "s8"}
   def nx_dtype_to_arrow({:s, 16}), do: {:ok, "s16"}
   def nx_dtype_to_arrow({:s, 32}), do: {:ok, "s32"}
@@ -87,7 +88,7 @@ defmodule ExArrow.Schema.Mapper do
   Boolean columns (`"bool"`) map to `{:u, 8}` because Nx represents booleans
   as unsigned 8-bit integers with values 0 and 1.
   """
-  @spec arrow_dtype_to_nx(arrow_dtype()) :: {:ok, Nx.dtype()} | {:error, String.t()}
+  @spec arrow_dtype_to_nx(arrow_dtype()) :: {:ok, nx_dtype()} | {:error, String.t()}
   def arrow_dtype_to_nx("s8"), do: {:ok, {:s, 8}}
   def arrow_dtype_to_nx("s16"), do: {:ok, {:s, 16}}
   def arrow_dtype_to_nx("s32"), do: {:ok, {:s, 32}}

--- a/lib/ex_arrow/stream.ex
+++ b/lib/ex_arrow/stream.ex
@@ -61,6 +61,11 @@ defmodule ExArrow.Stream do
   @opaque t :: %__MODULE__{resource: reference(), backend: :ipc | :adbc | :parquet | :flight_sql}
   defstruct [:resource, backend: :ipc]
 
+  @doc false
+  @spec stream?(term()) :: boolean()
+  def stream?(%__MODULE__{}), do: true
+  def stream?(_), do: false
+
   @doc """
   Returns the schema of this stream (without consuming it).
   Returns `{:error, message}` if the stream is invalid (e.g. poisoned lock).

--- a/lib/ex_arrow/table.ex
+++ b/lib/ex_arrow/table.ex
@@ -1,30 +1,87 @@
 defmodule ExArrow.Table do
   @moduledoc """
-  Arrow table handle (opaque reference to native table).
+  An Arrow table: a collection of record batches with a shared schema.
 
-  A table is a collection of record batches with a shared schema.
-  Data stays in native memory.
+  A `Table` is a logical view over one or more `ExArrow.RecordBatch` instances
+  that share the same schema.  Unlike `ExArrow.Stream` (which is lazy and
+  backed by a native resource), `Table` is an Elixir-side aggregation of
+  already-materialised batches.
+
+  ## Position in the hierarchy
+
+      Schema ── Field (metadata)
+                  │
+      RecordBatch ── Array (one per column)
+                        │
+      Table ── RecordBatch (one or more, shared schema)
+                        │
+      Stream ── RecordBatch (lazy sequence)
+
+  ## When to use Table vs Stream
+
+  - Use `Table` when you have all batches in hand (e.g. after collecting a
+    stream) and want a convenient container with `schema/1`, `num_rows/1`,
+    and `batches/1`.
+  - Use `Stream` for lazy consumption from IPC, Flight, ADBC, or Parquet
+    sources.
   """
+
+  alias ExArrow.RecordBatch
   alias ExArrow.Schema
 
-  @opaque t :: %__MODULE__{resource: reference()}
-  defstruct [:resource]
+  @type t :: %__MODULE__{
+          schema: Schema.t(),
+          batches: [RecordBatch.t()]
+        }
+
+  defstruct [:schema, :batches]
 
   @doc """
-  Returns the schema of this table.
-  Stub: returns nil until NIF is implemented.
+  Create a Table from a list of record batches.
+
+  All batches must share the same schema.  The schema is taken from the first
+  batch.  If the list is empty, returns `{:error, message}`.
+
+  Returns `{:ok, table}` or `{:error, message}`.
+
+  ## Examples
+
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream}  = ExArrow.IPC.Reader.from_binary(ipc_bin)
+      batches = ExArrow.Stream.to_list(stream)
+      {:ok, table} = ExArrow.Table.from_batches(batches)
+      ExArrow.Table.num_rows(table)  #=> 2
   """
-  @spec schema(t()) :: Schema.t() | nil
-  def schema(_table) do
-    nil
+  @spec from_batches([RecordBatch.t()]) :: {:ok, t()} | {:error, String.t()}
+  def from_batches([]), do: {:error, "cannot create Table from empty batch list"}
+
+  def from_batches([first | _] = batches) do
+    schema = RecordBatch.schema(first)
+    {:ok, %__MODULE__{schema: schema, batches: batches}}
   end
 
   @doc """
-  Returns the number of rows in this table.
-  Stub: returns 0 until NIF is implemented.
+  Returns the schema of this table.
+  """
+  @spec schema(t()) :: Schema.t()
+  def schema(%__MODULE__{schema: s}), do: s
+
+  @doc """
+  Returns the list of record batches in this table.
+  """
+  @spec batches(t()) :: [RecordBatch.t()]
+  def batches(%__MODULE__{batches: b}), do: b
+
+  @doc """
+  Returns the total number of rows across all batches in this table.
+
+  ## Examples
+
+      {:ok, table} = ExArrow.Table.from_batches(batches)
+      ExArrow.Table.num_rows(table)  #=> sum of all batch row counts
   """
   @spec num_rows(t()) :: non_neg_integer()
-  def num_rows(_table) do
-    0
+  def num_rows(%__MODULE__{batches: batches}) do
+    Enum.sum(Enum.map(batches, &RecordBatch.num_rows/1))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExArrow.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.6.0"
   @source_url "https://github.com/thanos/ex_arrow"
 
   def project do
@@ -99,6 +99,10 @@ defmodule ExArrow.MixProject do
       source_url: @source_url,
       source_ref: "v#{@version}",
       extras: [
+        "guides/01_arrow_for_elixir_developers.md",
+        "guides/02_explorer_integration.md",
+        "guides/03_nx_integration.md",
+        "guides/04_arrow_ecosystem.md",
         "docs/overview.md",
         "docs/memory_model.md",
         "docs/ipc_guide.md",
@@ -112,6 +116,7 @@ defmodule ExArrow.MixProject do
         "docs/benchmarks.md"
       ],
       groups_for_modules: [
+        "Data interchange": [ExArrow.DataFrame, ExArrow.Schema.Mapper],
         IPC: [ExArrow.IPC.Reader, ExArrow.IPC.Writer, ExArrow.IPC.File],
         Parquet: [ExArrow.Parquet.Reader, ExArrow.Parquet.Writer],
         "Compute kernels": [ExArrow.Compute],
@@ -138,7 +143,7 @@ defmodule ExArrow.MixProject do
         ],
         "C Data Interface": [ExArrow.CDI],
         "Optional bridges": [ExArrow.Explorer, ExArrow.Nx],
-        "Core types": [ExArrow.Stream, ExArrow.RecordBatch, ExArrow.Schema, ExArrow.Field]
+        "Core types": [ExArrow.Stream, ExArrow.RecordBatch, ExArrow.Schema, ExArrow.Field, ExArrow.Array, ExArrow.Table]
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,8 @@ defmodule ExArrow.MixProject do
       test_coverage: [tool: ExCoveralls],
       dialyzer: [
         plt_file: {:no_warn, "priv/plts/project.plt"},
-        plt_add_apps: [:mix]
+        plt_add_apps: [:mix],
+        ignore_warnings: "dialyzer_ignore.exs"
       ],
       preferred_cli_env: [
         coveralls: :test,
@@ -143,7 +144,14 @@ defmodule ExArrow.MixProject do
         ],
         "C Data Interface": [ExArrow.CDI],
         "Optional bridges": [ExArrow.Explorer, ExArrow.Nx],
-        "Core types": [ExArrow.Stream, ExArrow.RecordBatch, ExArrow.Schema, ExArrow.Field, ExArrow.Array, ExArrow.Table]
+        "Core types": [
+          ExArrow.Stream,
+          ExArrow.RecordBatch,
+          ExArrow.Schema,
+          ExArrow.Field,
+          ExArrow.Array,
+          ExArrow.Table
+        ]
       ]
     ]
   end

--- a/native/ex_arrow_native/src/ipc.rs
+++ b/native/ex_arrow_native/src/ipc.rs
@@ -3,7 +3,7 @@
 use std::io::Cursor;
 use std::sync::Arc;
 
-use arrow::array::{Int64Array, StringArray};
+use arrow::array::{BooleanArray, Int64Array, StringArray};
 use arrow::record_batch::RecordBatch;
 use arrow_array::types::{
     Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
@@ -125,7 +125,9 @@ pub fn ipc_reader_from_file<'a>(env: Env<'a>, path: String) -> Term<'a> {
     ok_encode(env, ResourceArc::new(stream))
 }
 
-/// Return list of fields for a schema: [{name, type_atom}, ...]. type_atom is :int64, :float64, :utf8, :binary, :boolean, :null, etc.
+/// Return list of fields for a schema: [{name, type_atom, nullable}, ...].
+/// type_atom is :int64, :float64, :utf8, :binary, :boolean, :null, etc.
+/// nullable is a boolean indicating whether the field allows null values.
 #[rustler::nif]
 pub fn schema_fields<'a>(env: Env<'a>, schema: ResourceArc<ExArrowSchema>) -> Term<'a> {
     let fields: Vec<Term> = schema
@@ -136,6 +138,7 @@ pub fn schema_fields<'a>(env: Env<'a>, schema: ResourceArc<ExArrowSchema>) -> Te
             (
                 f.name().encode(env),
                 data_type_to_atom(env, f.data_type()).encode(env),
+                f.is_nullable().encode(env),
             )
                 .encode(env)
         })
@@ -147,7 +150,16 @@ fn data_type_to_atom(env: Env, dt: &arrow_schema::DataType) -> rustler::types::a
     let s = match dt {
         arrow_schema::DataType::Null => "null",
         arrow_schema::DataType::Boolean => "boolean",
+        arrow_schema::DataType::Int8 => "int8",
+        arrow_schema::DataType::Int16 => "int16",
+        arrow_schema::DataType::Int32 => "int32",
         arrow_schema::DataType::Int64 => "int64",
+        arrow_schema::DataType::UInt8 => "uint8",
+        arrow_schema::DataType::UInt16 => "uint16",
+        arrow_schema::DataType::UInt32 => "uint32",
+        arrow_schema::DataType::UInt64 => "uint64",
+        arrow_schema::DataType::Float16 => "float16",
+        arrow_schema::DataType::Float32 => "float32",
         arrow_schema::DataType::Float64 => "float64",
         arrow_schema::DataType::Utf8 => "utf8",
         arrow_schema::DataType::LargeUtf8 => "large_utf8",
@@ -157,6 +169,11 @@ fn data_type_to_atom(env: Env, dt: &arrow_schema::DataType) -> rustler::types::a
         arrow_schema::DataType::LargeList(_) => "large_list",
         arrow_schema::DataType::Struct(_) => "struct",
         arrow_schema::DataType::Timestamp(_, _) => "timestamp",
+        arrow_schema::DataType::Date32 => "date32",
+        arrow_schema::DataType::Date64 => "date64",
+        arrow_schema::DataType::Time32(_) => "time32",
+        arrow_schema::DataType::Time64(_) => "time64",
+        arrow_schema::DataType::Duration(_) => "duration",
         arrow_schema::DataType::Decimal128(_, _) => "decimal128",
         arrow_schema::DataType::Decimal256(_, _) => "decimal256",
         arrow_schema::DataType::Dictionary(_, _) => "dictionary",
@@ -461,6 +478,26 @@ fn extract_primitive_buffer<'a>(env: Env<'a>, array: &ArrayRef) -> Term<'a> {
         DataType::UInt64 => primitive_buffer!(env, array, UInt64Type, "u64"),
         DataType::Float32 => primitive_buffer!(env, array, Float32Type, "f32"),
         DataType::Float64 => primitive_buffer!(env, array, Float64Type, "f64"),
+        DataType::Boolean => {
+            let bool_arr: &BooleanArray = match array.as_any().downcast_ref() {
+                Some(a) => a,
+                None => return err_encode(env, "internal: boolean downcast failed"),
+            };
+            let len = bool_arr.len();
+            let mut byte_buf = vec![0u8; len];
+            for i in 0..len {
+                if bool_arr.value(i) {
+                    byte_buf[i] = 1;
+                }
+            }
+            let mut owned = match rustler::OwnedBinary::new(len) {
+                Some(b) => b,
+                None => return err_encode(env, "binary alloc"),
+            };
+            owned.as_mut_slice().copy_from_slice(&byte_buf);
+            let binary = rustler::Binary::from_owned(owned, env);
+            ok_encode(env, (binary, "bool", len as u64))
+        }
         dt => err_encode(env, &format!("unsupported column type for Nx: {:?}", dt)),
     }
 }
@@ -573,6 +610,18 @@ fn build_column_array(bytes: &[u8], dtype_str: &str, length: usize) -> Result<(D
         "u64" => build_col!(bytes, length, u64, DataType::UInt64),
         "f32" => build_col!(bytes, length, f32, DataType::Float32),
         "f64" => build_col!(bytes, length, f64, DataType::Float64),
+        "bool" => {
+            if bytes.len() != length {
+                return Err(format!(
+                    "binary length mismatch for bool: expected {} bytes, got {}",
+                    length,
+                    bytes.len()
+                ));
+            }
+            let bool_vals: Vec<bool> = bytes.iter().map(|&b| b != 0).collect();
+            let array: ArrayRef = Arc::new(BooleanArray::from(bool_vals));
+            (DataType::Boolean, array)
+        }
         other => return Err(format!("unknown dtype '{}' for column creation", other)),
     };
     Ok(pair)

--- a/native/ex_arrow_native/src/ipc.rs
+++ b/native/ex_arrow_native/src/ipc.rs
@@ -571,6 +571,28 @@ pub fn record_batch_from_column_binaries<'a>(
     }
 }
 
+/// Concatenate multiple record batches that share a schema into a single batch.
+///
+/// All input batches must have identical schemas. Returns {:ok, batch_ref} or
+/// {:error, msg}. An empty list returns an error.
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn record_batch_concat<'a>(
+    env: Env<'a>,
+    batches: Vec<ResourceArc<ExArrowRecordBatch>>,
+) -> Term<'a> {
+    let Some(first) = batches.first() else {
+        return err_encode(env, "cannot concatenate an empty list of batches");
+    };
+
+    let schema = first.batch.schema();
+    let owned: Vec<RecordBatch> = batches.iter().map(|b| b.batch.clone()).collect();
+
+    match arrow::compute::concat_batches(&schema, &owned) {
+        Ok(batch) => ok_encode(env, ResourceArc::new(ExArrowRecordBatch { batch })),
+        Err(e) => err_encode(env, &e.to_string()),
+    }
+}
+
 // ── Column-array builder (shared by single-column and multi-column NIFs) ─────
 
 macro_rules! build_col {

--- a/native/ex_arrow_native/src/ipc.rs
+++ b/native/ex_arrow_native/src/ipc.rs
@@ -486,7 +486,9 @@ fn extract_primitive_buffer<'a>(env: Env<'a>, array: &ArrayRef) -> Term<'a> {
             let len = bool_arr.len();
             let mut byte_buf = vec![0u8; len];
             for i in 0..len {
-                if bool_arr.value(i) {
+                // is_null check ensures null slots emit 0 instead of the
+                // unspecified backing bit that value(i) returns.
+                if !bool_arr.is_null(i) && bool_arr.value(i) {
                     byte_buf[i] = 1;
                 }
             }

--- a/test/ex_arrow/data_frame_test.exs
+++ b/test/ex_arrow/data_frame_test.exs
@@ -3,6 +3,8 @@ defmodule ExArrow.DataFrameTest do
 
   alias ExArrow.DataFrame
   alias ExArrow.Explorer, as: ExArrowExplorer
+  alias ExArrow.RecordBatch
+  alias ExArrow.Stream
 
   @moduletag :explorer
 
@@ -11,8 +13,8 @@ defmodule ExArrow.DataFrameTest do
       test "converts a small dataframe to a single batch" do
         df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
         assert {:ok, batch} = DataFrame.to_arrow(df)
-        assert ExArrow.RecordBatch.num_rows(batch) == 3
-        assert ExArrow.RecordBatch.column_names(batch) == ["x", "y"]
+        assert RecordBatch.num_rows(batch) == 3
+        assert RecordBatch.column_names(batch) == ["x", "y"]
       end
 
       # Regression for issue #200 (C1): a large dataframe that Explorer splits
@@ -22,12 +24,11 @@ defmodule ExArrow.DataFrameTest do
         n = 2_000_000
         df = Explorer.DataFrame.new(x: Enum.to_list(1..n))
 
-        # Confirm the precondition: Explorer really does split this frame.
         assert {:ok, batches} = ExArrowExplorer.to_record_batches(df)
         assert length(batches) > 1
 
         assert {:ok, batch} = DataFrame.to_arrow(df)
-        assert ExArrow.RecordBatch.num_rows(batch) == n
+        assert RecordBatch.num_rows(batch) == n
       end
 
       test "preserves values across the concatenation boundary" do
@@ -40,21 +41,36 @@ defmodule ExArrow.DataFrameTest do
         recovered = Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "x"))
         assert recovered == values
       end
+
+      test "returns error for empty record batch list" do
+        assert {:error, msg} = ExArrow.Native.record_batch_concat([])
+        assert msg =~ "empty"
+      end
     end
 
-    describe "from_arrow/1" do
-      test "converts a RecordBatch to a dataframe" do
+    describe "from_arrow/1 dispatches by struct type" do
+      test "RecordBatch path: round-trips a dataframe" do
         df = Explorer.DataFrame.new(x: [1, 2, 3])
         {:ok, batch} = DataFrame.to_arrow(df)
         assert {:ok, df2} = DataFrame.from_arrow(batch)
         assert Explorer.DataFrame.n_rows(df2) == 3
       end
 
-      test "converts a Stream to a dataframe" do
+      test "Stream path: round-trips a dataframe" do
         df = Explorer.DataFrame.new(x: [1, 2, 3])
         {:ok, stream} = ExArrowExplorer.to_stream(df)
         assert {:ok, df2} = DataFrame.from_arrow(stream)
         assert Explorer.DataFrame.n_rows(df2) == 3
+      end
+
+      test "returns error for unsupported input type" do
+        assert {:error, msg} = DataFrame.from_arrow("not a batch")
+        assert msg =~ "RecordBatch" or msg =~ "Stream"
+      end
+
+      test "returns error for a bare map" do
+        assert {:error, msg} = DataFrame.from_arrow(%{})
+        assert msg =~ "RecordBatch" or msg =~ "Stream"
       end
     end
   else

--- a/test/ex_arrow/data_frame_test.exs
+++ b/test/ex_arrow/data_frame_test.exs
@@ -4,7 +4,6 @@ defmodule ExArrow.DataFrameTest do
   alias ExArrow.DataFrame
   alias ExArrow.Explorer, as: ExArrowExplorer
   alias ExArrow.RecordBatch
-  alias ExArrow.Stream
 
   @moduletag :explorer
 
@@ -42,9 +41,15 @@ defmodule ExArrow.DataFrameTest do
         assert recovered == values
       end
 
-      test "returns error for empty record batch list" do
-        assert {:error, msg} = ExArrow.Native.record_batch_concat([])
-        assert msg =~ "empty"
+      test "returns an error when Explorer produces no batches" do
+        stub = ExArrow.DataFrameTest.ExplorerStubEmpty
+
+        Process.put({DataFrame, :explorer_impl}, stub)
+        on_exit(fn -> Process.delete({DataFrame, :explorer_impl}) end)
+
+        df = Explorer.DataFrame.new(x: [1, 2, 3])
+        assert {:error, msg} = DataFrame.to_arrow(df)
+        assert msg =~ "no batches"
       end
     end
 
@@ -79,4 +84,10 @@ defmodule ExArrow.DataFrameTest do
       assert msg =~ "Explorer"
     end
   end
+end
+
+defmodule ExArrow.DataFrameTest.ExplorerStubEmpty do
+  @moduledoc false
+
+  def to_record_batches(_df), do: {:ok, []}
 end

--- a/test/ex_arrow/data_frame_test.exs
+++ b/test/ex_arrow/data_frame_test.exs
@@ -1,0 +1,66 @@
+defmodule ExArrow.DataFrameTest do
+  use ExUnit.Case, async: true
+
+  alias ExArrow.DataFrame
+  alias ExArrow.Explorer, as: ExArrowExplorer
+
+  @moduletag :explorer
+
+  if Code.ensure_loaded?(Explorer.DataFrame) do
+    describe "to_arrow/1" do
+      test "converts a small dataframe to a single batch" do
+        df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+        assert {:ok, batch} = DataFrame.to_arrow(df)
+        assert ExArrow.RecordBatch.num_rows(batch) == 3
+        assert ExArrow.RecordBatch.column_names(batch) == ["x", "y"]
+      end
+
+      # Regression for issue #200 (C1): a large dataframe that Explorer splits
+      # into multiple IPC batches previously returned only the first batch,
+      # silently dropping rows.  All batches must now be concatenated.
+      test "preserves the full row count when Explorer splits into many batches" do
+        n = 2_000_000
+        df = Explorer.DataFrame.new(x: Enum.to_list(1..n))
+
+        # Confirm the precondition: Explorer really does split this frame.
+        assert {:ok, batches} = ExArrowExplorer.to_record_batches(df)
+        assert length(batches) > 1
+
+        assert {:ok, batch} = DataFrame.to_arrow(df)
+        assert ExArrow.RecordBatch.num_rows(batch) == n
+      end
+
+      test "preserves values across the concatenation boundary" do
+        n = 2_000_000
+        values = Enum.to_list(1..n)
+        df = Explorer.DataFrame.new(x: values)
+
+        assert {:ok, batch} = DataFrame.to_arrow(df)
+        {:ok, df2} = DataFrame.from_arrow(batch)
+        recovered = Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "x"))
+        assert recovered == values
+      end
+    end
+
+    describe "from_arrow/1" do
+      test "converts a RecordBatch to a dataframe" do
+        df = Explorer.DataFrame.new(x: [1, 2, 3])
+        {:ok, batch} = DataFrame.to_arrow(df)
+        assert {:ok, df2} = DataFrame.from_arrow(batch)
+        assert Explorer.DataFrame.n_rows(df2) == 3
+      end
+
+      test "converts a Stream to a dataframe" do
+        df = Explorer.DataFrame.new(x: [1, 2, 3])
+        {:ok, stream} = ExArrowExplorer.to_stream(df)
+        assert {:ok, df2} = DataFrame.from_arrow(stream)
+        assert Explorer.DataFrame.n_rows(df2) == 3
+      end
+    end
+  else
+    test "returns descriptive error when Explorer is not loaded" do
+      assert {:error, msg} = DataFrame.to_arrow(:ignored)
+      assert msg =~ "Explorer"
+    end
+  end
+end

--- a/test/ex_arrow/explorer_property_test.exs
+++ b/test/ex_arrow/explorer_property_test.exs
@@ -1,0 +1,68 @@
+defmodule ExArrow.ExplorerPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :explorer
+
+  if Code.ensure_loaded?(Explorer.DataFrame) do
+    property "from_dataframe/to_dataframe round-trip preserves column names and row count" do
+      check all(
+              n <- integer(1..50),
+              col_names <- list_of(string(:alphanumeric, min_length: 1, max_length: 8), min_length: 1, max_length: 5),
+              max_runs: 20
+            ) do
+        unique_names = col_names |> Enum.uniq() |> Enum.take(5)
+        data = Enum.map(unique_names, fn name -> {String.to_existing_atom(name), Enum.to_list(1..n//1)} end)
+        df = Explorer.DataFrame.new(data)
+
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+
+        assert Explorer.DataFrame.n_rows(df2) == n
+        assert Enum.sort(Explorer.DataFrame.names(df2)) == Enum.sort(unique_names)
+      end
+    end
+
+    property "from_dataframe/to_dataframe round-trip preserves integer values" do
+      check all(
+              values <- list_of(integer(-1000..1000), min_length: 1, max_length: 100),
+              max_runs: 20
+            ) do
+        df = Explorer.DataFrame.new(x: values)
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        recovered = Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "x"))
+        assert recovered == values
+      end
+    end
+
+    property "from_dataframe/to_dataframe round-trip preserves float values" do
+      check all(
+              values <- list_of(float(), min_length: 1, max_length: 50),
+              max_runs: 20
+            ) do
+        df = Explorer.DataFrame.new(x: values)
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        recovered = Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "x"))
+        assert length(recovered) == length(values)
+        for {a, b} <- Enum.zip(recovered, values) do
+          assert_in_delta a, b, 0.001
+        end
+      end
+    end
+
+    property "from_dataframe/to_dataframe round-trip preserves boolean values" do
+      check all(
+              values <- list_of(boolean(), min_length: 1, max_length: 50),
+              max_runs: 20
+            ) do
+        df = Explorer.DataFrame.new(flags: values)
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        recovered = Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "flags"))
+        assert recovered == values
+      end
+    end
+  end
+end

--- a/test/ex_arrow/explorer_property_test.exs
+++ b/test/ex_arrow/explorer_property_test.exs
@@ -11,12 +11,10 @@ defmodule ExArrow.ExplorerPropertyTest do
       check all(
               n <- integer(1..50),
               num_cols <- integer(1..5),
-              col_names <-
-                list_of(member_of(@safe_atoms), min_length: num_cols, max_length: num_cols),
+              unique_names <-
+                uniq_list_of(member_of(@safe_atoms), min_length: num_cols, max_length: num_cols),
               max_runs: 20
             ) do
-        unique_names = col_names |> Enum.uniq() |> Enum.take(num_cols)
-
         data =
           Enum.map(unique_names, fn name ->
             {name, Enum.to_list(1..n//1)}

--- a/test/ex_arrow/explorer_property_test.exs
+++ b/test/ex_arrow/explorer_property_test.exs
@@ -5,21 +5,32 @@ defmodule ExArrow.ExplorerPropertyTest do
   @moduletag :explorer
 
   if Code.ensure_loaded?(Explorer.DataFrame) do
+    @safe_atoms ~w[x y z a b c d e f g h]a
+
     property "from_dataframe/to_dataframe round-trip preserves column names and row count" do
       check all(
               n <- integer(1..50),
-              col_names <- list_of(string(:alphanumeric, min_length: 1, max_length: 8), min_length: 1, max_length: 5),
+              num_cols <- integer(1..5),
+              col_names <-
+                list_of(member_of(@safe_atoms), min_length: num_cols, max_length: num_cols),
               max_runs: 20
             ) do
-        unique_names = col_names |> Enum.uniq() |> Enum.take(5)
-        data = Enum.map(unique_names, fn name -> {String.to_existing_atom(name), Enum.to_list(1..n//1)} end)
+        unique_names = col_names |> Enum.uniq() |> Enum.take(num_cols)
+
+        data =
+          Enum.map(unique_names, fn name ->
+            {name, Enum.to_list(1..n//1)}
+          end)
+
         df = Explorer.DataFrame.new(data)
 
         {:ok, batch} = ExArrow.from_dataframe(df)
         {:ok, df2} = ExArrow.to_dataframe(batch)
 
         assert Explorer.DataFrame.n_rows(df2) == n
-        assert Enum.sort(Explorer.DataFrame.names(df2)) == Enum.sort(unique_names)
+
+        assert Enum.sort(Explorer.DataFrame.names(df2)) ==
+                 Enum.sort(Enum.map(unique_names, &Atom.to_string/1))
       end
     end
 
@@ -46,6 +57,7 @@ defmodule ExArrow.ExplorerPropertyTest do
         {:ok, df2} = ExArrow.to_dataframe(batch)
         recovered = Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "x"))
         assert length(recovered) == length(values)
+
         for {a, b} <- Enum.zip(recovered, values) do
           assert_in_delta a, b, 0.001
         end

--- a/test/ex_arrow/explorer_roundtrip_test.exs
+++ b/test/ex_arrow/explorer_roundtrip_test.exs
@@ -4,7 +4,6 @@ defmodule ExArrow.ExplorerRoundtripTest do
   alias ExArrow.Explorer, as: ExArrowExplorer
 
   @moduletag :explorer
-  @nx_available Code.ensure_loaded?(Nx)
 
   if Code.ensure_loaded?(Explorer.DataFrame) do
     describe "ExArrow.from_dataframe/1 and ExArrow.to_dataframe/1 round-trip" do
@@ -45,18 +44,6 @@ defmodule ExArrow.ExplorerRoundtripTest do
 
         # Nulls come back as nil; non-null booleans are exact
         assert flags_vals == [true, nil, false, nil]
-      end
-
-      # Regression for issue #201 (L1): boolean NIF extraction previously
-      # ignored the null bitmap, returning arbitrary bits for null slots.
-      # Now null slots always emit 0.
-      test "boolean column with nulls: Nx extraction emits 0 at null positions" do
-        if @nx_available do
-          df = Explorer.DataFrame.new(flags: [true, nil, false], x: [1, 2, 3])
-          {:ok, batch} = ExArrow.from_dataframe(df)
-          {:ok, tensor} = ExArrow.Nx.column_to_tensor(batch, "flags")
-          assert Nx.to_list(tensor) == [1, 0, 0]
-        end
       end
 
       test "preserves boolean column" do
@@ -131,6 +118,27 @@ defmodule ExArrow.ExplorerRoundtripTest do
         {:ok, stream} = ExArrowExplorer.to_stream(df)
         {:ok, df2} = ExArrow.DataFrame.from_arrow(stream)
         assert Explorer.DataFrame.n_rows(df2) == 3
+      end
+    end
+
+    # Regression for issue #201 (L1): boolean NIF extraction previously
+    # ignored the null bitmap, returning arbitrary bits for null slots.
+    # These tests require both Explorer and Nx.
+    if Code.ensure_loaded?(Nx) do
+      describe "boolean column Nx extraction with null handling" do
+        test "boolean column without nulls round-trips via Nx" do
+          df = Explorer.DataFrame.new(flags: [true, false, true], x: [1, 2, 3])
+          {:ok, batch} = ExArrow.from_dataframe(df)
+          {:ok, tensor} = ExArrow.Nx.column_to_tensor(batch, "flags")
+          assert Nx.to_list(tensor) == [1, 0, 1]
+        end
+
+        test "boolean column with nulls: null positions emit 0 in Nx" do
+          df = Explorer.DataFrame.new(flags: [true, nil, false], x: [1, 2, 3])
+          {:ok, batch} = ExArrow.from_dataframe(df)
+          {:ok, tensor} = ExArrow.Nx.column_to_tensor(batch, "flags")
+          assert Nx.to_list(tensor) == [1, 0, 0]
+        end
       end
     end
 

--- a/test/ex_arrow/explorer_roundtrip_test.exs
+++ b/test/ex_arrow/explorer_roundtrip_test.exs
@@ -1,0 +1,130 @@
+defmodule ExArrow.ExplorerRoundtripTest do
+  use ExUnit.Case, async: true
+
+  alias ExArrow.Explorer, as: ExArrowExplorer
+
+  @moduletag :explorer
+
+  if Code.ensure_loaded?(Explorer.DataFrame) do
+    describe "ExArrow.from_dataframe/1 and ExArrow.to_dataframe/1 round-trip" do
+      test "preserves column names" do
+        df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        assert Explorer.DataFrame.names(df2) == Explorer.DataFrame.names(df)
+      end
+
+      test "preserves row count" do
+        df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        assert Explorer.DataFrame.n_rows(df2) == Explorer.DataFrame.n_rows(df)
+      end
+
+      test "preserves values" do
+        df = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        assert Explorer.DataFrame.to_rows(df2) == Explorer.DataFrame.to_rows(df)
+      end
+
+      test "preserves schema with integer and float columns" do
+        df = Explorer.DataFrame.new(ints: [10, 20], floats: [1.5, 2.5])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        assert Explorer.DataFrame.dtypes(df2) == Explorer.DataFrame.dtypes(df)
+      end
+
+      test "preserves boolean column" do
+        df = Explorer.DataFrame.new(flags: [true, false, true], name: ["a", "b", "c"])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        assert Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "flags")) ==
+                 Explorer.Series.to_list(Explorer.DataFrame.pull(df, "flags"))
+      end
+
+      test "preserves nullability" do
+        df = Explorer.DataFrame.new(x: [1, 2, nil], y: ["a", nil, "c"])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        schema = ExArrow.RecordBatch.schema(batch)
+        fields = ExArrow.Schema.fields(schema)
+        assert Enum.all?(fields, & &1.nullable)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        assert Explorer.DataFrame.n_rows(df2) == 3
+      end
+
+      test "nullable columns round-trip correctly" do
+        df = Explorer.DataFrame.new(x: [1, 2, nil], y: ["a", nil, "c"])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        assert Explorer.DataFrame.n_rows(df2) == 3
+        x_vals = Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "x"))
+        assert Enum.at(x_vals, 0) == 1
+        assert Enum.at(x_vals, 2) == nil
+      end
+
+      test "non-nullable source data round-trips correctly" do
+        df = Explorer.DataFrame.new(x: [1, 2, 3])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        x_vals = Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "x"))
+        assert x_vals == [1, 2, 3]
+      end
+
+      test "handles single-column dataframe" do
+        df = Explorer.DataFrame.new(val: [42])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        assert ExArrow.RecordBatch.num_rows(batch) == 1
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+        assert Explorer.DataFrame.n_rows(df2) == 1
+      end
+
+      test "handles empty dataframe" do
+        df = Explorer.DataFrame.new(x: Explorer.Series.from_list([]))
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        assert ExArrow.RecordBatch.num_rows(batch) == 0
+      end
+    end
+
+    describe "ExArrow.DataFrame.from_arrow/1 and ExArrow.DataFrame.to_arrow/1 round-trip" do
+      test "preserves column names" do
+        df = Explorer.DataFrame.new(a: [10, 20], b: ["hello", "world"])
+        {:ok, batch} = ExArrow.DataFrame.to_arrow(df)
+        {:ok, df2} = ExArrow.DataFrame.from_arrow(batch)
+        assert Explorer.DataFrame.names(df2) == Explorer.DataFrame.names(df)
+      end
+
+      test "preserves values" do
+        df = Explorer.DataFrame.new(a: [10, 20], b: ["hello", "world"])
+        {:ok, batch} = ExArrow.DataFrame.to_arrow(df)
+        {:ok, df2} = ExArrow.DataFrame.from_arrow(batch)
+        assert Explorer.DataFrame.to_rows(df2) == Explorer.DataFrame.to_rows(df)
+      end
+
+      test "accepts ExArrow.Stream for from_arrow" do
+        df = Explorer.DataFrame.new(x: [1, 2, 3])
+        {:ok, stream} = ExArrowExplorer.to_stream(df)
+        {:ok, df2} = ExArrow.DataFrame.from_arrow(stream)
+        assert Explorer.DataFrame.n_rows(df2) == 3
+      end
+    end
+
+    describe "error cases" do
+      test "from_dataframe returns error when Explorer not a dataframe" do
+        assert {:error, msg} = ExArrow.from_dataframe(:not_a_df)
+        assert is_binary(msg)
+      end
+
+      test "to_dataframe returns error for invalid batch" do
+        bad_batch = %ExArrow.RecordBatch{resource: make_ref()}
+        assert {:error, msg} = ExArrow.to_dataframe(bad_batch)
+        assert is_binary(msg)
+      end
+    end
+  else
+    test "returns descriptive error when Explorer is not loaded" do
+      assert {:error, msg} = ExArrow.from_dataframe(:ignored)
+      assert msg =~ "Explorer"
+    end
+  end
+end

--- a/test/ex_arrow/explorer_roundtrip_test.exs
+++ b/test/ex_arrow/explorer_roundtrip_test.exs
@@ -4,6 +4,7 @@ defmodule ExArrow.ExplorerRoundtripTest do
   alias ExArrow.Explorer, as: ExArrowExplorer
 
   @moduletag :explorer
+  @nx_available Code.ensure_loaded?(Nx)
 
   if Code.ensure_loaded?(Explorer.DataFrame) do
     describe "ExArrow.from_dataframe/1 and ExArrow.to_dataframe/1 round-trip" do
@@ -33,6 +34,29 @@ defmodule ExArrow.ExplorerRoundtripTest do
         {:ok, batch} = ExArrow.from_dataframe(df)
         {:ok, df2} = ExArrow.to_dataframe(batch)
         assert Explorer.DataFrame.dtypes(df2) == Explorer.DataFrame.dtypes(df)
+      end
+
+      test "boolean column with nulls round-trips correctly" do
+        df = Explorer.DataFrame.new(flags: [true, nil, false, nil], x: [1, 2, 3, 4])
+        {:ok, batch} = ExArrow.from_dataframe(df)
+        {:ok, df2} = ExArrow.to_dataframe(batch)
+
+        flags_vals = Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "flags"))
+
+        # Nulls come back as nil; non-null booleans are exact
+        assert flags_vals == [true, nil, false, nil]
+      end
+
+      # Regression for issue #201 (L1): boolean NIF extraction previously
+      # ignored the null bitmap, returning arbitrary bits for null slots.
+      # Now null slots always emit 0.
+      test "boolean column with nulls: Nx extraction emits 0 at null positions" do
+        if @nx_available do
+          df = Explorer.DataFrame.new(flags: [true, nil, false], x: [1, 2, 3])
+          {:ok, batch} = ExArrow.from_dataframe(df)
+          {:ok, tensor} = ExArrow.Nx.column_to_tensor(batch, "flags")
+          assert Nx.to_list(tensor) == [1, 0, 0]
+        end
       end
 
       test "preserves boolean column" do

--- a/test/ex_arrow/explorer_roundtrip_test.exs
+++ b/test/ex_arrow/explorer_roundtrip_test.exs
@@ -39,6 +39,7 @@ defmodule ExArrow.ExplorerRoundtripTest do
         df = Explorer.DataFrame.new(flags: [true, false, true], name: ["a", "b", "c"])
         {:ok, batch} = ExArrow.from_dataframe(df)
         {:ok, df2} = ExArrow.to_dataframe(batch)
+
         assert Explorer.Series.to_list(Explorer.DataFrame.pull(df2, "flags")) ==
                  Explorer.Series.to_list(Explorer.DataFrame.pull(df, "flags"))
       end

--- a/test/ex_arrow/field_test.exs
+++ b/test/ex_arrow/field_test.exs
@@ -2,26 +2,37 @@ defmodule ExArrow.FieldTest do
   use ExUnit.Case, async: true
 
   describe "Field struct" do
-    test "holds name and type" do
-      field = %ExArrow.Field{name: "id", type: :int64}
+    test "holds name, type, and nullable" do
+      field = %ExArrow.Field{name: "id", type: :int64, nullable: false}
       assert field.name == "id"
       assert field.type == :int64
-      assert %ExArrow.Field{name: _, type: _} = field
+      assert field.nullable == false
     end
 
-    test "new/2 returns struct with given name and type" do
-      assert %ExArrow.Field{name: "x", type: :utf8} = ExArrow.Field.new("x", :utf8)
+    test "nullable defaults to true" do
+      field = %ExArrow.Field{name: "id", type: :int64}
+      assert field.nullable == true
+    end
+
+    test "new/2 returns struct with given name and type, nullable defaults to true" do
+      assert %ExArrow.Field{name: "x", type: :utf8, nullable: true} = ExArrow.Field.new("x", :utf8)
+    end
+
+    test "new/3 returns struct with explicit nullable" do
+      assert %ExArrow.Field{name: "x", type: :int64, nullable: false} = ExArrow.Field.new("x", :int64, false)
     end
 
     @tag :ipc
-    test "matches structs returned from Schema.fields" do
+    test "matches structs returned from Schema.fields with nullable flag" do
       {:ok, binary} = ExArrow.Native.ipc_test_fixture_binary()
       {:ok, stream} = ExArrow.IPC.Reader.from_binary(binary)
       {:ok, schema} = ExArrow.Stream.schema(stream)
       fields = ExArrow.Schema.fields(schema)
 
-      assert [%ExArrow.Field{name: "id", type: :int64}, %ExArrow.Field{name: "name", type: :utf8}] =
-               fields
+      assert [
+               %ExArrow.Field{name: "id", type: :int64, nullable: false},
+               %ExArrow.Field{name: "name", type: :utf8, nullable: false}
+             ] = fields
     end
   end
 end

--- a/test/ex_arrow/field_test.exs
+++ b/test/ex_arrow/field_test.exs
@@ -15,11 +15,13 @@ defmodule ExArrow.FieldTest do
     end
 
     test "new/2 returns struct with given name and type, nullable defaults to true" do
-      assert %ExArrow.Field{name: "x", type: :utf8, nullable: true} = ExArrow.Field.new("x", :utf8)
+      assert %ExArrow.Field{name: "x", type: :utf8, nullable: true} =
+               ExArrow.Field.new("x", :utf8)
     end
 
     test "new/3 returns struct with explicit nullable" do
-      assert %ExArrow.Field{name: "x", type: :int64, nullable: false} = ExArrow.Field.new("x", :int64, false)
+      assert %ExArrow.Field{name: "x", type: :int64, nullable: false} =
+               ExArrow.Field.new("x", :int64, false)
     end
 
     @tag :ipc

--- a/test/ex_arrow/flight_sql_client_impl_test.exs
+++ b/test/ex_arrow/flight_sql_client_impl_test.exs
@@ -1,6 +1,8 @@
 defmodule ExArrow.FlightSQL.ClientImplTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias ExArrow.FlightSQL.{Client, ClientImpl, Error}
 
   setup do
@@ -83,11 +85,16 @@ defmodule ExArrow.FlightSQL.ClientImplTest do
         ExArrow.FlightSQL.TestNativeFallbackError
       )
 
-      assert {:error, %Error{code: :transport_error, message: msg}} =
-               ClientImpl.connect("localhost:32010", [])
+      log =
+        capture_log(fn ->
+          assert {:error, %Error{code: :transport_error, message: msg}} =
+                   ClientImpl.connect("localhost:32010", [])
 
-      # The fallback clause calls inspect/1 on the unrecognised term.
-      assert msg =~ "unexpected_atom"
+          # The fallback clause calls inspect/1 on the unrecognised term.
+          assert msg =~ "unexpected_atom"
+        end)
+
+      assert log =~ "unexpected NIF error shape"
     end
   end
 

--- a/test/ex_arrow/nx_property_test.exs
+++ b/test/ex_arrow/nx_property_test.exs
@@ -1,0 +1,104 @@
+defmodule ExArrow.NxPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :nx
+
+  if Code.ensure_loaded?(Nx) do
+    property "rank-1 from_nx/to_nx round-trip preserves shape and values for s64" do
+      check all(
+              values <- list_of(integer(-1000..1000), min_length: 1, max_length: 100),
+              max_runs: 20
+            ) do
+        tensor = Nx.tensor(values, type: {:s, 64})
+        {:ok, batch} = ExArrow.from_nx(tensor)
+        {:ok, recovered} = ExArrow.to_nx(batch)
+        assert Nx.shape(recovered) == Nx.shape(tensor)
+        assert Nx.type(recovered) == {:s, 64}
+        assert Nx.to_list(recovered) == values
+      end
+    end
+
+    property "rank-1 from_nx/to_nx round-trip preserves shape and values for f64" do
+      check all(
+              values <- list_of(float(), min_length: 1, max_length: 50),
+              max_runs: 20
+            ) do
+        tensor = Nx.tensor(values, type: {:f, 64})
+        {:ok, batch} = ExArrow.from_nx(tensor)
+        {:ok, recovered} = ExArrow.to_nx(batch)
+        assert Nx.shape(recovered) == Nx.shape(tensor)
+        assert Nx.type(recovered) == {:f, 64}
+        for {a, b} <- Enum.zip(Nx.to_list(recovered), values) do
+          assert_in_delta a, b, 0.001
+        end
+      end
+    end
+
+    property "rank-1 from_nx/to_nx round-trip preserves u8 values" do
+      check all(
+              values <- list_of(integer(0..255), min_length: 1, max_length: 100),
+              max_runs: 20
+            ) do
+        tensor = Nx.tensor(values, type: {:u, 8})
+        {:ok, batch} = ExArrow.from_nx(tensor)
+        {:ok, recovered} = ExArrow.to_nx(batch)
+        assert Nx.shape(recovered) == Nx.shape(tensor)
+        assert Nx.type(recovered) == {:u, 8}
+        assert Nx.to_list(recovered) == values
+      end
+    end
+
+    property "rank-2 from_nx/to_nx round-trip preserves shape and values for s64" do
+      check all(
+              rows <- integer(1..10),
+              cols <- integer(2..5),
+              max_runs: 10
+            ) do
+        values = Enum.map(1..(rows * cols), fn i -> rem(i, 1000) end)
+        tensor = Nx.reshape(Nx.tensor(values, type: {:s, 64}), {rows, cols})
+        {:ok, batch} = ExArrow.from_nx(tensor)
+        {:ok, recovered} = ExArrow.to_nx(batch)
+        assert Nx.shape(recovered) == {rows, cols}
+        assert Nx.type(recovered) == {:s, 64}
+        assert Nx.to_list(recovered) == Nx.to_list(tensor)
+      end
+    end
+
+    property "boolean from_nx/to_nx round-trip preserves values" do
+      check all(
+              values <- list_of(boolean(), min_length: 1, max_length: 50),
+              max_runs: 20
+            ) do
+        int_values = Enum.map(values, fn true -> 1; false -> 0 end)
+        tensor = Nx.tensor(int_values, type: {:u, 8})
+        {:ok, batch} = ExArrow.from_nx(tensor, as: :boolean)
+        {:ok, recovered} = ExArrow.to_nx(batch)
+        assert Nx.type(recovered) == {:u, 8}
+        assert Nx.to_list(recovered) == int_values
+      end
+    end
+
+    property "Schema.Mapper round-trip: nx_dtype -> arrow -> nx_dtype is identity" do
+      check all(
+              nx_dtype <- one_of([
+                constant({:s, 8}),
+                constant({:s, 16}),
+                constant({:s, 32}),
+                constant({:s, 64}),
+                constant({:u, 8}),
+                constant({:u, 16}),
+                constant({:u, 32}),
+                constant({:u, 64}),
+                constant({:f, 32}),
+                constant({:f, 64})
+              ]),
+              max_runs: 20
+            ) do
+        {:ok, arrow} = ExArrow.Schema.Mapper.nx_dtype_to_arrow(nx_dtype)
+        {:ok, nx_back} = ExArrow.Schema.Mapper.arrow_dtype_to_nx(arrow)
+        assert nx_back == nx_dtype
+      end
+    end
+  end
+end

--- a/test/ex_arrow/nx_property_test.exs
+++ b/test/ex_arrow/nx_property_test.exs
@@ -53,8 +53,8 @@ defmodule ExArrow.NxPropertyTest do
     property "rank-2 from_nx/to_nx round-trip preserves shape and values for s64" do
       check all(
               rows <- integer(1..10),
-              cols <- integer(2..5),
-              max_runs: 10
+              cols <- integer(2..20),
+              max_runs: 20
             ) do
         values = Enum.map(1..(rows * cols), fn i -> rem(i, 1000) end)
         tensor = Nx.reshape(Nx.tensor(values, type: {:s, 64}), {rows, cols})

--- a/test/ex_arrow/nx_property_test.exs
+++ b/test/ex_arrow/nx_property_test.exs
@@ -29,6 +29,7 @@ defmodule ExArrow.NxPropertyTest do
         {:ok, recovered} = ExArrow.to_nx(batch)
         assert Nx.shape(recovered) == Nx.shape(tensor)
         assert Nx.type(recovered) == {:f, 64}
+
         for {a, b} <- Enum.zip(Nx.to_list(recovered), values) do
           assert_in_delta a, b, 0.001
         end
@@ -70,7 +71,12 @@ defmodule ExArrow.NxPropertyTest do
               values <- list_of(boolean(), min_length: 1, max_length: 50),
               max_runs: 20
             ) do
-        int_values = Enum.map(values, fn true -> 1; false -> 0 end)
+        int_values =
+          Enum.map(values, fn
+            true -> 1
+            false -> 0
+          end)
+
         tensor = Nx.tensor(int_values, type: {:u, 8})
         {:ok, batch} = ExArrow.from_nx(tensor, as: :boolean)
         {:ok, recovered} = ExArrow.to_nx(batch)
@@ -81,18 +87,19 @@ defmodule ExArrow.NxPropertyTest do
 
     property "Schema.Mapper round-trip: nx_dtype -> arrow -> nx_dtype is identity" do
       check all(
-              nx_dtype <- one_of([
-                constant({:s, 8}),
-                constant({:s, 16}),
-                constant({:s, 32}),
-                constant({:s, 64}),
-                constant({:u, 8}),
-                constant({:u, 16}),
-                constant({:u, 32}),
-                constant({:u, 64}),
-                constant({:f, 32}),
-                constant({:f, 64})
-              ]),
+              nx_dtype <-
+                one_of([
+                  constant({:s, 8}),
+                  constant({:s, 16}),
+                  constant({:s, 32}),
+                  constant({:s, 64}),
+                  constant({:u, 8}),
+                  constant({:u, 16}),
+                  constant({:u, 32}),
+                  constant({:u, 64}),
+                  constant({:f, 32}),
+                  constant({:f, 64})
+                ]),
               max_runs: 20
             ) do
         {:ok, arrow} = ExArrow.Schema.Mapper.nx_dtype_to_arrow(nx_dtype)

--- a/test/ex_arrow/nx_roundtrip_test.exs
+++ b/test/ex_arrow/nx_roundtrip_test.exs
@@ -71,8 +71,23 @@ defmodule ExArrow.NxRoundtripTest do
         {:ok, recovered} = ExArrow.to_nx(batch)
         assert Nx.shape(recovered) == Nx.shape(tensor)
         assert Nx.type(recovered) == Nx.type(tensor)
-        assert Nx.to_flat_list(recovered) |> Enum.map(&Nx.to_number/1) ==
-                 Nx.to_flat_list(tensor) |> Enum.map(&Nx.to_number/1)
+
+        assert recovered |> Nx.to_flat_list() |> Enum.map(&Nx.to_number/1) ==
+                 tensor |> Nx.to_flat_list() |> Enum.map(&Nx.to_number/1)
+      end
+
+      # Regression for issue #200 (C2): with more than 10 columns, naive
+      # column naming (c0..cN) plus map-based ordering reordered columns
+      # lexicographically ("c10" < "c2") and corrupted the data.
+      for cols <- [11, 12, 25, 100, 256] do
+        test "rank-2 round-trip preserves column order with #{cols} columns" do
+          tensor = Nx.iota({3, unquote(cols)}, type: {:s, 64})
+          {:ok, batch} = ExArrow.from_nx(tensor)
+          assert ExArrow.RecordBatch.num_columns(batch) == unquote(cols)
+          {:ok, recovered} = ExArrow.to_nx(batch)
+          assert Nx.shape(recovered) == {3, unquote(cols)}
+          assert Nx.to_list(recovered) == Nx.to_list(tensor)
+        end
       end
     end
 
@@ -88,6 +103,14 @@ defmodule ExArrow.NxRoundtripTest do
         assert {:error, msg} = ExArrow.from_nx(tensor)
         assert msg =~ "rank"
       end
+
+      # Regression for issue #200 (C3): the :as option was silently dropped
+      # for rank-2 tensors, producing UInt8 columns instead of Boolean.
+      test "rejects as: :boolean for rank-2 tensors" do
+        tensor = Nx.tensor([[1, 0], [0, 1]], type: {:u, 8})
+        assert {:error, msg} = ExArrow.from_nx(tensor, as: :boolean)
+        assert msg =~ "rank-2"
+      end
     end
 
     describe "ExArrow.to_nx/1 — multi-column batch to rank-2" do
@@ -96,6 +119,7 @@ defmodule ExArrow.NxRoundtripTest do
           "a" => Nx.tensor([1, 2, 3], type: {:s, 64}),
           "b" => Nx.tensor([4, 5, 6], type: {:s, 64})
         }
+
         {:ok, batch} = ExArrow.Nx.from_tensors(tensors)
         {:ok, result} = ExArrow.to_nx(batch)
         assert tuple_size(Nx.shape(result)) == 2
@@ -106,6 +130,7 @@ defmodule ExArrow.NxRoundtripTest do
           "a" => Nx.tensor([1, 2, 3], type: {:s, 64}),
           "b" => Nx.tensor([1.0, 2.0, 3.0], type: {:f, 64})
         }
+
         {:ok, batch} = ExArrow.Nx.from_tensors(tensors)
         assert {:error, msg} = ExArrow.to_nx(batch)
         assert msg =~ "uniform"

--- a/test/ex_arrow/nx_roundtrip_test.exs
+++ b/test/ex_arrow/nx_roundtrip_test.exs
@@ -1,0 +1,138 @@
+defmodule ExArrow.NxRoundtripTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :nx
+
+  if Code.ensure_loaded?(Nx) do
+    describe "ExArrow.from_nx/1 and ExArrow.to_nx/1 — rank-1 round-trip" do
+      for {dtype, label, values} <- [
+            {{:u, 8}, "u8", [1, 0, 1, 255]},
+            {{:s, 64}, "s64", [100, -200, 300, 0]},
+            {{:f, 32}, "f32", [1.0, 2.0, 3.0]},
+            {{:f, 64}, "f64", [1.5, 2.5, 3.5]},
+            {{:u, 8}, "boolean_as_u8", [1, 0, 1, 0]}
+          ] do
+        test "round-trip preserves shape, dtype, values for #{label}" do
+          tensor = Nx.tensor(unquote(values), type: unquote(dtype))
+          {:ok, batch} = ExArrow.from_nx(tensor)
+          {:ok, recovered} = ExArrow.to_nx(batch)
+          assert Nx.shape(recovered) == Nx.shape(tensor)
+          assert Nx.type(recovered) == unquote(dtype)
+          assert Nx.to_list(recovered) == Nx.to_list(tensor)
+        end
+      end
+    end
+
+    describe "ExArrow.from_nx/1 — boolean tensor" do
+      test "creates Arrow Boolean column with as: :boolean" do
+        tensor = Nx.tensor([1, 0, 1, 0], type: {:u, 8})
+        {:ok, batch} = ExArrow.from_nx(tensor, as: :boolean)
+        schema = ExArrow.RecordBatch.schema(batch)
+        [field] = ExArrow.Schema.fields(schema)
+        assert field.type == :boolean
+      end
+
+      test "round-trip boolean column preserves values" do
+        tensor = Nx.tensor([1, 0, 1, 0], type: {:u, 8})
+        {:ok, batch} = ExArrow.from_nx(tensor, as: :boolean)
+        {:ok, recovered} = ExArrow.to_nx(batch)
+        assert Nx.type(recovered) == {:u, 8}
+        assert Nx.to_list(recovered) == [1, 0, 1, 0]
+      end
+
+      test "as: :boolean fails for non-u8 tensor" do
+        tensor = Nx.tensor([1, 2, 3], type: {:s, 64})
+        assert {:error, msg} = ExArrow.from_nx(tensor, as: :boolean)
+        assert msg =~ "as: :boolean"
+      end
+    end
+
+    describe "ExArrow.from_nx/1 and ExArrow.to_nx/1 — rank-2 round-trip" do
+      test "rank-2 tensor creates multi-column batch" do
+        tensor = Nx.tensor([[1, 2, 3], [4, 5, 6]], type: {:s, 64})
+        {:ok, batch} = ExArrow.from_nx(tensor)
+        schema = ExArrow.RecordBatch.schema(batch)
+        assert length(ExArrow.Schema.fields(schema)) == 3
+        assert ExArrow.RecordBatch.num_rows(batch) == 2
+      end
+
+      test "rank-2 round-trip preserves shape, dtype, and values" do
+        tensor = Nx.tensor([[1, 2, 3], [4, 5, 6]], type: {:s, 64})
+        {:ok, batch} = ExArrow.from_nx(tensor)
+        {:ok, recovered} = ExArrow.to_nx(batch)
+        assert Nx.shape(recovered) == Nx.shape(tensor)
+        assert Nx.type(recovered) == Nx.type(tensor)
+        assert Nx.to_list(recovered) == Nx.to_list(tensor)
+      end
+
+      test "rank-2 f32 round-trip" do
+        tensor = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: {:f, 32})
+        {:ok, batch} = ExArrow.from_nx(tensor)
+        {:ok, recovered} = ExArrow.to_nx(batch)
+        assert Nx.shape(recovered) == Nx.shape(tensor)
+        assert Nx.type(recovered) == Nx.type(tensor)
+        assert Nx.to_flat_list(recovered) |> Enum.map(&Nx.to_number/1) ==
+                 Nx.to_flat_list(tensor) |> Enum.map(&Nx.to_number/1)
+      end
+    end
+
+    describe "ExArrow.from_nx/1 — error cases" do
+      test "returns error for unsupported dtype" do
+        tensor = Nx.tensor([1, 2], type: {:bf, 16})
+        assert {:error, msg} = ExArrow.from_nx(tensor)
+        assert msg =~ "unsupported"
+      end
+
+      test "returns error for rank > 2" do
+        tensor = Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], type: {:s, 64})
+        assert {:error, msg} = ExArrow.from_nx(tensor)
+        assert msg =~ "rank"
+      end
+    end
+
+    describe "ExArrow.to_nx/1 — multi-column batch to rank-2" do
+      test "uniform numeric batch stacks into rank-2" do
+        tensors = %{
+          "a" => Nx.tensor([1, 2, 3], type: {:s, 64}),
+          "b" => Nx.tensor([4, 5, 6], type: {:s, 64})
+        }
+        {:ok, batch} = ExArrow.Nx.from_tensors(tensors)
+        {:ok, result} = ExArrow.to_nx(batch)
+        assert tuple_size(Nx.shape(result)) == 2
+      end
+
+      test "mixed dtype batch returns error for to_nx" do
+        tensors = %{
+          "a" => Nx.tensor([1, 2, 3], type: {:s, 64}),
+          "b" => Nx.tensor([1.0, 2.0, 3.0], type: {:f, 64})
+        }
+        {:ok, batch} = ExArrow.Nx.from_tensors(tensors)
+        assert {:error, msg} = ExArrow.to_nx(batch)
+        assert msg =~ "uniform"
+      end
+
+      test "single-column batch returns rank-1 tensor" do
+        tensor = Nx.tensor([10, 20, 30], type: {:s, 64})
+        {:ok, batch} = ExArrow.from_nx(tensor)
+        {:ok, result} = ExArrow.to_nx(batch)
+        assert Nx.shape(result) == {3}
+      end
+    end
+
+    describe "ExArrow.to_nx/1 with non-numeric columns" do
+      test "skips non-numeric columns and returns numeric ones" do
+        {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+        {:ok, stream} = ExArrow.IPC.Reader.from_binary(ipc_bin)
+        batch = ExArrow.Stream.next(stream)
+        {:ok, tensor} = ExArrow.to_nx(batch)
+        assert Nx.shape(tensor) == {2}
+        assert Nx.type(tensor) == {:s, 64}
+      end
+    end
+  else
+    test "returns descriptive error when Nx is not loaded" do
+      assert {:error, msg} = ExArrow.from_nx(:ignored)
+      assert msg =~ "Nx"
+    end
+  end
+end

--- a/test/ex_arrow/record_batch_test.exs
+++ b/test/ex_arrow/record_batch_test.exs
@@ -1,0 +1,46 @@
+defmodule ExArrow.RecordBatchTest do
+  use ExUnit.Case, async: true
+
+  alias ExArrow.IPC
+  alias ExArrow.RecordBatch
+  alias ExArrow.Stream
+
+  @moduletag :ipc
+
+  describe "schema/1" do
+    test "returns the batch's schema" do
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream} = IPC.Reader.from_binary(ipc_bin)
+      batch = Stream.next(stream)
+      schema = RecordBatch.schema(batch)
+      assert %ExArrow.Schema{} = schema
+    end
+  end
+
+  describe "num_rows/1" do
+    test "returns the row count" do
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream} = IPC.Reader.from_binary(ipc_bin)
+      batch = Stream.next(stream)
+      assert RecordBatch.num_rows(batch) == 2
+    end
+  end
+
+  describe "num_columns/1" do
+    test "returns the column count" do
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream} = IPC.Reader.from_binary(ipc_bin)
+      batch = Stream.next(stream)
+      assert RecordBatch.num_columns(batch) == 2
+    end
+  end
+
+  describe "column_names/1" do
+    test "returns column names" do
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream} = IPC.Reader.from_binary(ipc_bin)
+      batch = Stream.next(stream)
+      assert RecordBatch.column_names(batch) == ["id", "name"]
+    end
+  end
+end

--- a/test/ex_arrow/record_batch_test.exs
+++ b/test/ex_arrow/record_batch_test.exs
@@ -43,4 +43,23 @@ defmodule ExArrow.RecordBatchTest do
       assert RecordBatch.column_names(batch) == ["id", "name"]
     end
   end
+
+  describe "Native.record_batch_concat/1" do
+    test "concatenates batches with the same schema, summing rows" do
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream} = IPC.Reader.from_binary(ipc_bin)
+      batch = Stream.next(stream)
+      ref = RecordBatch.resource_ref(batch)
+
+      assert {:ok, merged_ref} = ExArrow.Native.record_batch_concat([ref, ref, ref])
+      merged = RecordBatch.from_ref(merged_ref)
+      assert RecordBatch.num_rows(merged) == RecordBatch.num_rows(batch) * 3
+      assert RecordBatch.column_names(merged) == RecordBatch.column_names(batch)
+    end
+
+    test "returns an error for an empty list" do
+      assert {:error, msg} = ExArrow.Native.record_batch_concat([])
+      assert msg =~ "empty"
+    end
+  end
 end

--- a/test/ex_arrow/schema_mapper_test.exs
+++ b/test/ex_arrow/schema_mapper_test.exs
@@ -1,0 +1,235 @@
+defmodule ExArrow.Schema.MapperTest do
+  use ExUnit.Case, async: true
+
+  alias ExArrow.Schema.Mapper
+
+  describe "nx_dtype_to_arrow/1" do
+    for {nx_dtype, arrow_str} <- [
+          {{:s, 8}, "s8"},
+          {{:s, 16}, "s16"},
+          {{:s, 32}, "s32"},
+          {{:s, 64}, "s64"},
+          {{:u, 8}, "u8"},
+          {{:u, 16}, "u16"},
+          {{:u, 32}, "u32"},
+          {{:u, 64}, "u64"},
+          {{:f, 32}, "f32"},
+          {{:f, 64}, "f64"}
+        ] do
+      test "maps #{inspect(nx_dtype)} to #{inspect(arrow_str)}" do
+        assert {:ok, unquote(arrow_str)} = Mapper.nx_dtype_to_arrow(unquote(nx_dtype))
+      end
+    end
+
+    test "returns error for unsupported dtype" do
+      assert {:error, msg} = Mapper.nx_dtype_to_arrow({:bf, 16})
+      assert msg =~ "unsupported"
+    end
+  end
+
+  describe "arrow_dtype_to_nx/1" do
+    for {arrow_str, nx_dtype} <- [
+          {"s8", {:s, 8}},
+          {"s16", {:s, 16}},
+          {"s32", {:s, 32}},
+          {"s64", {:s, 64}},
+          {"u8", {:u, 8}},
+          {"u16", {:u, 16}},
+          {"u32", {:u, 32}},
+          {"u64", {:u, 64}},
+          {"f32", {:f, 32}},
+          {"f64", {:f, 64}}
+        ] do
+      test "maps #{inspect(arrow_str)} to #{inspect(nx_dtype)}" do
+        assert {:ok, unquote(nx_dtype)} = Mapper.arrow_dtype_to_nx(unquote(arrow_str))
+      end
+    end
+
+    test "maps bool to {:u, 8}" do
+      assert {:ok, {:u, 8}} = Mapper.arrow_dtype_to_nx("bool")
+    end
+
+    test "returns error for utf8" do
+      assert {:error, msg} = Mapper.arrow_dtype_to_nx("utf8")
+      assert msg =~ "unsupported"
+    end
+  end
+
+  describe "explorer_dtype_to_arrow/1" do
+    test "maps :integer to s64" do
+      assert {:ok, "s64"} = Mapper.explorer_dtype_to_arrow(:integer)
+    end
+
+    test "maps :float to f64" do
+      assert {:ok, "f64"} = Mapper.explorer_dtype_to_arrow(:float)
+    end
+
+    test "maps :boolean to bool" do
+      assert {:ok, "bool"} = Mapper.explorer_dtype_to_arrow(:boolean)
+    end
+
+    test "maps :string to utf8" do
+      assert {:ok, "utf8"} = Mapper.explorer_dtype_to_arrow(:string)
+    end
+
+    test "returns error for :date" do
+      assert {:error, msg} = Mapper.explorer_dtype_to_arrow(:date)
+      assert msg =~ "unsupported"
+    end
+
+    test "returns error for :datetime" do
+      assert {:error, msg} = Mapper.explorer_dtype_to_arrow(:datetime)
+      assert msg =~ "unsupported"
+    end
+
+    test "returns error for :nil" do
+      assert {:error, msg} = Mapper.explorer_dtype_to_arrow(:nil)
+      assert msg =~ "unsupported"
+    end
+  end
+
+  describe "arrow_dtype_to_explorer/1" do
+    for s <- ["s8", "s16", "s32", "s64", "u8", "u16", "u32", "u64"] do
+      test "maps #{inspect(s)} to :integer" do
+        assert {:ok, :integer} = Mapper.arrow_dtype_to_explorer(unquote(s))
+      end
+    end
+
+    for s <- ["f32", "f64"] do
+      test "maps #{inspect(s)} to :float" do
+        assert {:ok, :float} = Mapper.arrow_dtype_to_explorer(unquote(s))
+      end
+    end
+
+    test "maps bool to :boolean" do
+      assert {:ok, :boolean} = Mapper.arrow_dtype_to_explorer("bool")
+    end
+
+    test "maps utf8 to :string" do
+      assert {:ok, :string} = Mapper.arrow_dtype_to_explorer("utf8")
+    end
+
+    test "returns error for unknown dtype" do
+      assert {:error, msg} = Mapper.arrow_dtype_to_explorer("timestamp")
+      assert msg =~ "unsupported"
+    end
+  end
+
+  describe "arrow_type_atom_to_dtype/1" do
+    for {atom, str} <- [
+          {:boolean, "bool"},
+          {:int8, "s8"},
+          {:int16, "s16"},
+          {:int32, "s32"},
+          {:int64, "s64"},
+          {:uint8, "u8"},
+          {:uint16, "u16"},
+          {:uint32, "u32"},
+          {:uint64, "u64"},
+          {:float32, "f32"},
+          {:float64, "f64"},
+          {:utf8, "utf8"},
+          {:large_utf8, "utf8"}
+        ] do
+      test "maps #{atom} to #{inspect(str)}" do
+        assert {:ok, unquote(str)} = Mapper.arrow_type_atom_to_dtype(unquote(atom))
+      end
+    end
+
+    test "returns error for :timestamp" do
+      assert {:error, msg} = Mapper.arrow_type_atom_to_dtype(:timestamp)
+      assert msg =~ "unsupported"
+    end
+
+    test "returns error for :null" do
+      assert {:error, msg} = Mapper.arrow_type_atom_to_dtype(:null)
+      assert msg =~ "unsupported"
+    end
+  end
+
+  describe "arrow_dtype_to_type_atom/1" do
+    for {str, atom} <- [
+          {"s8", :int8},
+          {"s16", :int16},
+          {"s32", :int32},
+          {"s64", :int64},
+          {"u8", :uint8},
+          {"u16", :uint16},
+          {"u32", :uint32},
+          {"u64", :uint64},
+          {"f32", :float32},
+          {"f64", :float64},
+          {"bool", :boolean},
+          {"utf8", :utf8}
+        ] do
+      test "maps #{inspect(str)} to #{atom}" do
+        assert {:ok, unquote(atom)} = Mapper.arrow_dtype_to_type_atom(unquote(str))
+      end
+    end
+
+    test "returns error for unknown dtype" do
+      assert {:error, msg} = Mapper.arrow_dtype_to_type_atom("date32")
+      assert msg =~ "unsupported"
+    end
+  end
+
+  describe "numeric?/1" do
+    for s <- ["s8", "s16", "s32", "s64", "u8", "u16", "u32", "u64", "f32", "f64", "bool"] do
+      test "returns true for #{inspect(s)}" do
+        assert Mapper.numeric?(unquote(s))
+      end
+    end
+
+    test "returns false for utf8" do
+      refute Mapper.numeric?("utf8")
+    end
+
+    test "returns false for unknown dtype" do
+      refute Mapper.numeric?("timestamp")
+    end
+  end
+
+  describe "round-trip: Nx <-> Arrow dtype string" do
+    for {nx_dtype, arrow_str} <- [
+          {{:s, 8}, "s8"},
+          {{:s, 16}, "s16"},
+          {{:s, 32}, "s32"},
+          {{:s, 64}, "s64"},
+          {{:u, 8}, "u8"},
+          {{:u, 16}, "u16"},
+          {{:u, 32}, "u32"},
+          {{:u, 64}, "u64"},
+          {{:f, 32}, "f32"},
+          {{:f, 64}, "f64"}
+        ] do
+      test "nx -> arrow -> nx identity for #{inspect(nx_dtype)}" do
+        {:ok, arrow} = Mapper.nx_dtype_to_arrow(unquote(nx_dtype))
+        {:ok, nx_back} = Mapper.arrow_dtype_to_nx(arrow)
+        assert nx_back == unquote(nx_dtype)
+      end
+    end
+  end
+
+  describe "round-trip: Arrow type atom <-> dtype string" do
+    for {atom, str} <- [
+          {:boolean, "bool"},
+          {:int8, "s8"},
+          {:int16, "s16"},
+          {:int32, "s32"},
+          {:int64, "s64"},
+          {:uint8, "u8"},
+          {:uint16, "u16"},
+          {:uint32, "u32"},
+          {:uint64, "u64"},
+          {:float32, "f32"},
+          {:float64, "f64"},
+          {:utf8, "utf8"}
+        ] do
+      test "atom -> dtype -> atom identity for #{atom}" do
+        {:ok, dtype} = Mapper.arrow_type_atom_to_dtype(unquote(atom))
+        {:ok, atom_back} = Mapper.arrow_dtype_to_type_atom(dtype)
+        assert atom_back == unquote(atom)
+      end
+    end
+  end
+end

--- a/test/ex_arrow/schema_mapper_test.exs
+++ b/test/ex_arrow/schema_mapper_test.exs
@@ -190,7 +190,7 @@ defmodule ExArrow.Schema.MapperTest do
   end
 
   describe "round-trip: Nx <-> Arrow dtype string" do
-    for {nx_dtype, arrow_str} <- [
+    for {nx_dtype, _arrow_str} <- [
           {{:s, 8}, "s8"},
           {{:s, 16}, "s16"},
           {{:s, 32}, "s32"},
@@ -211,7 +211,7 @@ defmodule ExArrow.Schema.MapperTest do
   end
 
   describe "round-trip: Arrow type atom <-> dtype string" do
-    for {atom, str} <- [
+    for {atom, _str} <- [
           {:boolean, "bool"},
           {:int8, "s8"},
           {:int16, "s16"},

--- a/test/ex_arrow/schema_mapper_test.exs
+++ b/test/ex_arrow/schema_mapper_test.exs
@@ -83,7 +83,7 @@ defmodule ExArrow.Schema.MapperTest do
     end
 
     test "returns error for :nil" do
-      assert {:error, msg} = Mapper.explorer_dtype_to_arrow(:nil)
+      assert {:error, msg} = Mapper.explorer_dtype_to_arrow(nil)
       assert msg =~ "unsupported"
     end
   end

--- a/test/ex_arrow/table_test.exs
+++ b/test/ex_arrow/table_test.exs
@@ -1,15 +1,56 @@
 defmodule ExArrow.TableTest do
   use ExUnit.Case, async: true
 
-  describe "stub API" do
-    test "schema/1 returns nil until NIF is implemented" do
-      table = %ExArrow.Table{resource: make_ref()}
-      assert ExArrow.Table.schema(table) == nil
+  alias ExArrow.IPC
+  alias ExArrow.Stream
+  alias ExArrow.Table
+
+  @moduletag :ipc
+
+  describe "from_batches/1" do
+    test "creates a table from a list of batches" do
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream} = IPC.Reader.from_binary(ipc_bin)
+      batches = Stream.to_list(stream)
+      {:ok, table} = Table.from_batches(batches)
+      assert %Table{} = table
     end
 
-    test "num_rows/1 returns 0 until NIF is implemented" do
-      table = %ExArrow.Table{resource: make_ref()}
-      assert ExArrow.Table.num_rows(table) == 0
+    test "returns error for empty list" do
+      assert {:error, msg} = Table.from_batches([])
+      assert msg =~ "empty"
+    end
+  end
+
+  describe "schema/1" do
+    test "returns the schema from the first batch" do
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream} = IPC.Reader.from_binary(ipc_bin)
+      batches = Stream.to_list(stream)
+      {:ok, table} = Table.from_batches(batches)
+      schema = Table.schema(table)
+      assert %ExArrow.Schema{} = schema
+      assert ExArrow.Schema.field_names(schema) == ["id", "name"]
+    end
+  end
+
+  describe "num_rows/1" do
+    test "returns total row count across all batches" do
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream} = IPC.Reader.from_binary(ipc_bin)
+      batches = Stream.to_list(stream)
+      {:ok, table} = Table.from_batches(batches)
+      assert Table.num_rows(table) == 2
+    end
+  end
+
+  describe "batches/1" do
+    test "returns the list of batches" do
+      {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
+      {:ok, stream} = IPC.Reader.from_binary(ipc_bin)
+      batches = Stream.to_list(stream)
+      {:ok, table} = Table.from_batches(batches)
+      assert Table.batches(table) == batches
     end
   end
 end

--- a/test/mix/tasks/ci_test.exs
+++ b/test/mix/tasks/ci_test.exs
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.CiTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureIO
+
   # Script path is overridable via application config for testing.
   setup do
     stub_path = Path.join(File.cwd!(), "test/support/ci_stub.sh")
@@ -11,7 +13,7 @@ defmodule Mix.Tasks.CiTest do
   test "run/1 executes script and succeeds when script exits 0", %{stub_path: stub_path} do
     Application.put_env(:ex_arrow, :ci_script_path, stub_path)
     # Task returns nil on success (no raise)
-    assert Mix.Tasks.Ci.run([]) == nil
+    capture_io(fn -> assert Mix.Tasks.Ci.run([]) == nil end)
   end
 
   test "run/1 raises when script path does not exist" do
@@ -26,8 +28,10 @@ defmodule Mix.Tasks.CiTest do
     fail_stub = Path.join(File.cwd!(), "test/support/ci_stub_fail.sh")
     Application.put_env(:ex_arrow, :ci_script_path, fail_stub)
 
-    assert_raise Mix.Error, ~r/CI script exited with code 1/, fn ->
-      Mix.Tasks.Ci.run([])
-    end
+    capture_io(fn ->
+      assert_raise Mix.Error, ~r/CI script exited with code 1/, fn ->
+        Mix.Tasks.Ci.run([])
+      end
+    end)
   end
 end


### PR DESCRIPTION
## v0.6.0 — Arrow as universal data interchange layer

 - closed #193, Add first-class Explorer and Nx interchange (ExArrow.from_dataframe/1, to_dataframe/1, ExArrow.DataFrame.from_arrow/1, to_arrow/1, ExArrow.from_nx/1, to_nx/1) with schema, nullability, shape, dtype, and value fidelity.
 - closed #194, Introduce ExArrow.Schema.Mapper as the single Explorer/Nx <-> Arrow mapping authority, extensible for future ExZarr and Dataset support.
 - closed #195, Add field nullability, improve and document Array/RecordBatch/Table and the Arrow hierarchy,
 - closed #196, add Benchee benchmarks (1K/100K/1M) and educational guides.
 - closed #197 Tests include unit, property, and doctests with coverage >= 85%.

**Files Added**
- lib/ex_arrow/schema/mapper.ex — ExArrow.Schema.Mapper: single authority for Arrow <-> Explorer/Nx type mapping
- lib/ex_arrow/data_frame.ex — ExArrow.DataFrame: from_arrow/1, to_arrow/1
- guides/01_arrow_for_elixir_developers.md
- guides/02_explorer_integration.md
- guides/03_nx_integration.md
- guides/04_arrow_ecosystem.md
- bench/explorer_arrow_bench.exs
- bench/nx_arrow_bench.exs
- test/ex_arrow/schema_mapper_test.exs
- test/ex_arrow/data_frame_test.exs (implicit via roundtrip tests)
- test/ex_arrow/explorer_roundtrip_test.exs
- test/ex_arrow/nx_roundtrip_test.exs
- test/ex_arrow/explorer_property_test.exs
- test/ex_arrow/nx_property_test.exs
- test/ex_arrow/record_batch_test.exs

**Files Modified**
- lib/ex_arrow.ex — added from_dataframe/1, to_dataframe/1, from_nx/1, to_nx/1, Arrow hierarchy docs
- lib/ex_arrow/field.ex — added nullable field
- lib/ex_arrow/schema.ex — fields/1 now populates nullability from NIF
- lib/ex_arrow/nx.ex — delegates to Schema.Mapper, added boolean support, from_tensor/3 with opts
- lib/ex_arrow/array.ex — improved moduledoc with hierarchy context
- lib/ex_arrow/record_batch.ex — added num_columns/1, column_names/1, improved moduledoc
- lib/ex_arrow/table.ex — replaced stub with from_batches/1, real schema/1, num_rows/1, batches/1
- native/ex_arrow_native/src/ipc.rs — schema_fields returns nullable, data_type_to_atom covers full int/float range, boolean buffer extraction and column creation
- mix.exs — version 0.6.0, ExDoc guides and module groups
- CHANGELOG.md — v0.6.0 entry
- README.md — Explorer/Nx interchange API, v0.6.0 roadmap, updated docs/links
- bench/run_all.exs — added new benchmark scripts
- test/ex_arrow/field_test.exs — nullable assertions
- test/ex_arrow/table_test.exs — real Table tests

**Architectural Decisions**
- Schema.Mapper as single type-mapping authority (replaces inlined dtype helpers in Nx)
- Rank-2 tensor rule: N columns named c0..c{N-1}, reversible for uniform-dtype batches
- Boolean mapping: Arrow Boolean <-> Nx {:u, 8} at the boundary
- Table: Elixir-side aggregation (not native NIF), honest rather than stub
- Explorer nullability: IPC round-trip through Explorer marks all columns nullable; data values preserved

