### PR TITLE
Implement ExArrow v0.6.1: Flight SQL prepared statement parameter binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,7 @@ jobs:
         uses: actions/cache@v5.0.5
         with:
           path: priv/plts
-          key: plt-core-1.20-29-${{ hashFiles('mix.lock') }}
-      - run: rm -f priv/plts/project.plt
+          key: plt-1.20-29-${{ hashFiles('mix.lock') }}
       - run: mix dialyzer
 
   # ── Test with Rust NIF ────────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,6 @@ jobs:
             mix-build-dialyzer-1.20-29-
 
       - run: mix deps.get
-      - name: Restore Dialyzer PLT cache
-        uses: actions/cache@v5.0.5
-        with:
-          path: priv/plts
-          key: plt-1.20-29-${{ hashFiles('mix.lock') }}
-      - run: mix dialyzer --plt
       - run: mix dialyzer
 
   # ── Test with Rust NIF ────────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,12 @@ jobs:
             mix-build-dialyzer-1.20-29-
 
       - run: mix deps.get
-      - run: mkdir -p priv/plts
       - name: Restore Dialyzer PLT cache
         uses: actions/cache@v5.0.5
         with:
           path: priv/plts
           key: plt-1.20-29-${{ hashFiles('mix.lock') }}
+      - run: mix dialyzer --plt
       - run: mix dialyzer
 
   # ── Test with Rust NIF ────────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
       - run: mix format --check-formatted
       - run: mix credo --strict
       - run: mix sobelow --exit --skip
+      - name: Check CHANGELOG version matches mix.exs
+        run: bash script/check_version
       - run: mix docs --warnings-as-errors
         env:
           MIX_ENV: dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-06-11
+
+### Added
+
+- **Flight SQL prepared statement parameter binding** —
+  `ExArrow.FlightSQL.Statement.bind/2` binds an `ExArrow.RecordBatch` of
+  parameters to a prepared statement before execution.  Supports all Arrow
+  column types compatible with the server's parameter schema.
+- **`ExArrow.FlightSQL.Statement.close/1`** — explicitly closes a prepared
+  statement and releases server-side resources via `ActionClosePreparedStatement`.
+  Idempotent: calling `close/1` on an already-closed statement returns `:ok`.
+  All subsequent operations on a closed statement return
+  `{:error, %Error{code: :protocol_error}}`.
+- **`ExArrow.FlightSQL.Statement.parameter_schema/1`** — returns the parameter
+  schema of a prepared statement, enabling callers to inspect expected column
+  names and Arrow types before binding.
+- **`ExArrow.RecordBatch.from_columns/4`** — creates a `RecordBatch` from
+  column-oriented binary data (names, binaries, dtype strings, row count).
+  Primary constructor for Flight SQL parameter binding.
+- **Rust NIF: `flight_sql_prepared_bind`** — binds a `RecordBatch` to a prepared
+  statement via `PreparedStatement::set_parameters`.
+- **Rust NIF: `flight_sql_prepared_close`** — closes a prepared statement via
+  `PreparedStatement::close`, consuming the statement handle.  The
+  `FlightSqlPreparedStatementResource` stores `Mutex<Option<PreparedStatement>>`
+  to support clean ownership transfer.
+- **Rust NIF: `flight_sql_prepared_parameter_schema`** — returns the parameter
+  schema from a prepared statement.
+
+### Changed
+
+- **`FlightSqlPreparedStatementResource.stmt`** changed from
+  `Mutex<PreparedStatement<Channel>>` to `Mutex<Option<PreparedStatement<Channel>>>`
+  to support proper `close/1` that consumes the statement handle.
+- **`ExArrow.FlightSQL.Statement`** struct now includes a `closed` field to
+  prevent operations on closed statements at the Elixir level.
+- **`Client.prepare/2` documentation** updated to reflect parameter binding
+  support and `close/1` lifecycle.
+
 ## [0.6.0] - 2026-06-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,37 +11,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Flight SQL prepared statement parameter binding** —
   `ExArrow.FlightSQL.Statement.bind/2` binds an `ExArrow.RecordBatch` of
-  parameters to a prepared statement before execution.  Supports all Arrow
-  column types compatible with the server's parameter schema.
+  parameters to a prepared statement before execution.  Returns `:ok` or
+  `{:error, %Error{}}`.
 - **`ExArrow.FlightSQL.Statement.close/1`** — explicitly closes a prepared
-  statement and releases server-side resources via `ActionClosePreparedStatement`.
-  Idempotent: calling `close/1` on an already-closed statement returns `:ok`.
-  All subsequent operations on a closed statement return
+  statement and releases server-side resources via
+  `ActionClosePreparedStatement`.  Idempotent: calling `close/1` on an
+  already-closed statement returns `:ok`.  Closed-state is tracked inside
+  the underlying NIF resource; subsequent calls to `bind/2`, `execute/1`,
+  `execute_update/1`, or `parameter_schema/1` return
   `{:error, %Error{code: :protocol_error}}`.
 - **`ExArrow.FlightSQL.Statement.parameter_schema/1`** — returns the parameter
   schema of a prepared statement, enabling callers to inspect expected column
   names and Arrow types before binding.
 - **`ExArrow.RecordBatch.from_columns/4`** — creates a `RecordBatch` from
   column-oriented binary data (names, binaries, dtype strings, row count).
-  Primary constructor for Flight SQL parameter binding.
-- **Rust NIF: `flight_sql_prepared_bind`** — binds a `RecordBatch` to a prepared
-  statement via `PreparedStatement::set_parameters`.
+  Returns `{:ok, t()} | {:error, String.t()}`.  Primary constructor for
+  building parameter batches.  Supported dtypes: `"s8"`, `"s16"`, `"s32"`,
+  `"s64"`, `"u8"`, `"u16"`, `"u32"`, `"u64"`, `"f32"`, `"f64"`, `"bool"`.
+  String, binary, date, timestamp, and duration types are not yet supported
+  by this constructor and will be added in a future release.
+- **Rust NIF: `flight_sql_prepared_bind`** — binds a `RecordBatch` to a
+  prepared statement via `PreparedStatement::set_parameters`.
 - **Rust NIF: `flight_sql_prepared_close`** — closes a prepared statement via
   `PreparedStatement::close`, consuming the statement handle.  The
   `FlightSqlPreparedStatementResource` stores `Mutex<Option<PreparedStatement>>`
-  to support clean ownership transfer.
+  to support clean ownership transfer and idempotent close.
 - **Rust NIF: `flight_sql_prepared_parameter_schema`** — returns the parameter
   schema from a prepared statement.
 
 ### Changed
 
 - **`FlightSqlPreparedStatementResource.stmt`** changed from
-  `Mutex<PreparedStatement<Channel>>` to `Mutex<Option<PreparedStatement<Channel>>>`
-  to support proper `close/1` that consumes the statement handle.
-- **`ExArrow.FlightSQL.Statement`** struct now includes a `closed` field to
-  prevent operations on closed statements at the Elixir level.
+  `Mutex<PreparedStatement<Channel>>` to
+  `Mutex<Option<PreparedStatement<Channel>>>` to support `close/1` that
+  consumes the statement handle.  Closed-state is detected by checking the
+  inner `Option`; all prepared-statement NIFs return
+  `{:error, {:protocol_error, 0, "statement is closed"}}` when called on a
+  closed handle.
 - **`Client.prepare/2` documentation** updated to reflect parameter binding
   support and `close/1` lifecycle.
+
+### Fixed
+
+- CI: Removed broken Dialyzer PLT cache that produced "Old PLT file" errors
+  when the cached PLT was incompatible with the current OTP/Elixir version.
+  The PLT now lives in `_build/dev/` (dialyxir's default location) and is
+  covered by the existing `_build` cache.
+- `script/ci`: Fixed `--warninsg-as-errors` typo in `mix docs` invocation.
 
 ## [0.6.0] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ExArrow.RecordBatch.from_columns/4`** — creates a `RecordBatch` from
   column-oriented binary data (names, binaries, dtype strings, row count).
   Returns `{:ok, t()} | {:error, String.t()}`.  Primary constructor for
-  building parameter batches.  Supported dtypes: `"s8"`, `"s16"`, `"s32"`,
-  `"s64"`, `"u8"`, `"u16"`, `"u32"`, `"u64"`, `"f32"`, `"f64"`, `"bool"`.
-  String, binary, date, timestamp, and duration types are not yet supported
-  by this constructor and will be added in a future release.
+  building parameter batches.  Supported dtypes:
+  - Signed integers: `"s8"`, `"s16"`, `"s32"`, `"s64"`
+  - Unsigned integers: `"u8"`, `"u16"`, `"u32"`, `"u64"`
+  - Floats: `"f32"`, `"f64"`
+  - Boolean: `"bool"`
+  - Date/time: `"date32"`, `"date64"`, `"timestamp_seconds"`,
+    `"timestamp_millis"`, `"timestamp_micros"`, `"timestamp_nanos"`,
+    `"duration_seconds"`, `"duration_millis"`, `"duration_micros"`,
+    `"duration_nanos"`
+  - Variable-length: `"utf8"`, `"large_utf8"`, `"binary"`, `"large_binary"`
+    (length-prefixed records, see `ExArrow.RecordBatch` moduledoc for the
+    wire format)
 - **Rust NIF: `flight_sql_prepared_bind`** — binds a `RecordBatch` to a
   prepared statement via `PreparedStatement::set_parameters`.
 - **Rust NIF: `flight_sql_prepared_close`** — closes a prepared statement via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Flight SQL prepared statement parameter binding** —
+- **Flight SQL prepared statement parameter binding**:
   `ExArrow.FlightSQL.Statement.bind/2` binds an `ExArrow.RecordBatch` of
   parameters to a prepared statement before execution.  Returns `:ok` or
   `{:error, %Error{}}`.
-- **`ExArrow.FlightSQL.Statement.close/1`** — explicitly closes a prepared
+- **`ExArrow.FlightSQL.Statement.close/1`**: closes a prepared
   statement and releases server-side resources via
   `ActionClosePreparedStatement`.  Idempotent: calling `close/1` on an
   already-closed statement returns `:ok`.  Closed-state is tracked inside
   the underlying NIF resource; subsequent calls to `bind/2`, `execute/1`,
   `execute_update/1`, or `parameter_schema/1` return
   `{:error, %Error{code: :protocol_error}}`.
-- **`ExArrow.FlightSQL.Statement.parameter_schema/1`** — returns the parameter
+- **`ExArrow.FlightSQL.Statement.parameter_schema/1`**: returns the parameter
   schema of a prepared statement, enabling callers to inspect expected column
   names and Arrow types before binding.
-- **`ExArrow.RecordBatch.from_columns/4`** — creates a `RecordBatch` from
+- **`ExArrow.RecordBatch.from_columns/4`**: creates a `RecordBatch` from
   column-oriented binary data (names, binaries, dtype strings, row count).
-  Returns `{:ok, t()} | {:error, String.t()}`.  Primary constructor for
+  Returns `{:ok, t()} | {:error, String.t()}`.  Constructor for
   building parameter batches.  Supported dtypes:
   - Signed integers: `"s8"`, `"s16"`, `"s32"`, `"s64"`
   - Unsigned integers: `"u8"`, `"u16"`, `"u32"`, `"u64"`
@@ -38,13 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Variable-length: `"utf8"`, `"large_utf8"`, `"binary"`, `"large_binary"`
     (length-prefixed records, see `ExArrow.RecordBatch` moduledoc for the
     wire format)
-- **Rust NIF: `flight_sql_prepared_bind`** — binds a `RecordBatch` to a
+- **Rust NIF: `flight_sql_prepared_bind`**: binds a `RecordBatch` to a
   prepared statement via `PreparedStatement::set_parameters`.
-- **Rust NIF: `flight_sql_prepared_close`** — closes a prepared statement via
+- **Rust NIF: `flight_sql_prepared_close`**: closes a prepared statement via
   `PreparedStatement::close`, consuming the statement handle.  The
   `FlightSqlPreparedStatementResource` stores `Mutex<Option<PreparedStatement>>`
   to support clean ownership transfer and idempotent close.
-- **Rust NIF: `flight_sql_prepared_parameter_schema`** — returns the parameter
+- **Rust NIF: `flight_sql_prepared_parameter_schema`**: returns the parameter
   schema from a prepared statement.
 
 ### Changed
@@ -58,6 +58,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closed handle.
 - **`Client.prepare/2` documentation** updated to reflect parameter binding
   support and `close/1` lifecycle.
+- **Minimum Rust `arrow-flight` crate version: 56**: Flight SQL prepared
+  statement support uses `PreparedStatement::set_parameters`, `close`, and
+  `parameter_schema` APIs available from `arrow-flight` v56.  Earlier crate
+  versions are missing these methods.  `Cargo.toml` pins `arrow-flight = "56"`.
+- **`Statement` struct is opaque**: the `closed` field from earlier
+  development builds has been removed.  Closed-state is now tracked inside
+  the NIF resource (`Mutex<Option<PreparedStatement>>`).  Code that pattern-
+  matched on `%Statement{closed: _}` must be updated to treat `Statement` as
+  an opaque handle and use `close/1` / `bind/2` / `execute/1` for lifecycle
+  queries.
 
 ### Fixed
 

--- a/lib/ex_arrow/flight_sql.ex
+++ b/lib/ex_arrow/flight_sql.ex
@@ -32,7 +32,7 @@ defmodule ExArrow.FlightSQL do
   - Ad-hoc SQL query execution (`query/2`, `query!/2`, `stream_query/2`)
   - DML execution with affected-row count (`execute/2`)
   - Lazy streaming of large result sets with `Enumerable` support (`stream_query/2`)
-  - Prepared statements (`Client.prepare/2`, `Statement.execute/1`, `Statement.execute_update/1`)
+  - Prepared statements with parameter binding (`Client.prepare/2`, `Statement.bind/2`, `Statement.execute/1`, `Statement.execute_update/1`, `Statement.close/1`, `Statement.parameter_schema/1`)
   - Metadata discovery: `get_tables/2`, `get_db_schemas/2`, `get_sql_info/1`
   - TLS connections (plaintext, OS trust store, custom CA)
   - Bearer-token and custom gRPC header injection
@@ -44,7 +44,7 @@ defmodule ExArrow.FlightSQL do
   - Bulk ingestion (`DoPut`)
   - Transactions (`BEGIN`, `COMMIT`, `ROLLBACK`)
   - Multi-endpoint distributed query results
-  - Parameter binding for prepared statements (v0.6.0)
+  - Parameter binding for prepared statements
   - Flight SQL server-side implementation (ExArrow is a client library only)
 
   ## Ecosystem integration

--- a/lib/ex_arrow/flight_sql/client.ex
+++ b/lib/ex_arrow/flight_sql/client.ex
@@ -52,7 +52,7 @@ defmodule ExArrow.FlightSQL.Client do
   validation requires a live server; see the `flight_sql_integration` test tag.
 
   Multi-endpoint `FlightInfo` responses (distributed queries) are not supported in
-  v0.5.0 — `query/2` returns `{:error, %Error{code: :multi_endpoint}}` in that case.
+  v0.5.0: `query/2` returns `{:error, %Error{code: :multi_endpoint}}` in that case.
 
   Transaction operations (`BEGIN`, `COMMIT`, `ROLLBACK`) are deferred to v0.6.0.
   """
@@ -68,7 +68,7 @@ defmodule ExArrow.FlightSQL.Client do
     Application.get_env(:ex_arrow, :flight_sql_client_impl, ExArrow.FlightSQL.ClientImpl)
   end
 
-  # ── Connection ────────────────────────────────────────────────────────────────
+  # Connection
 
   @doc """
   Connect to a Flight SQL server at the given URI.
@@ -103,7 +103,7 @@ defmodule ExArrow.FlightSQL.Client do
     impl().close(client)
   end
 
-  # ── Queries ───────────────────────────────────────────────────────────────────
+  # Queries
 
   @doc """
   Execute a SQL query and return a materialized result.
@@ -114,8 +114,8 @@ defmodule ExArrow.FlightSQL.Client do
   Returns `{:ok, %ExArrow.FlightSQL.Result{}}` or `{:error, %ExArrow.FlightSQL.Error{}}`.
 
   > #### Concurrency {: .warning}
-  > Concurrent calls on the **same** client handle are serialised — the underlying
-  > gRPC client requires exclusive access per call.  For parallel queries, create
+  > Concurrent calls on the **same** client handle are serialised; the underlying
+  > gRPC client requires exclusive access per call; for parallel queries, create
   > separate client handles with `connect/2`.
 
   ## Examples
@@ -163,15 +163,15 @@ defmodule ExArrow.FlightSQL.Client do
   Prefer this over `query/2` for large result sets.
 
   > #### Concurrency {: .warning}
-  > Concurrent calls on the **same** client handle are serialised — the underlying
-  > gRPC client requires exclusive access per call.  For parallel queries, create
+  > Concurrent calls on the **same** client handle are serialised; the underlying
+  > gRPC client requires exclusive access per call; for parallel queries, create
   > separate client handles with `connect/2`.
 
   ## Examples
 
       {:ok, stream} = ExArrow.FlightSQL.Client.stream_query(client, "SELECT * FROM large_table")
       schema = ExArrow.Stream.schema(stream)
-      ExArrow.Stream.to_list(stream)  # collect all — or iterate lazily with next/1
+      ExArrow.Stream.to_list(stream)  # collect all, or iterate lazily with next/1
   """
   @spec stream_query(t(), String.t()) :: {:ok, Stream.t()} | {:error, Error.t()}
   # sobelow_skip ["SQL.Query"]
@@ -181,7 +181,7 @@ defmodule ExArrow.FlightSQL.Client do
     impl().query(client, sql, [])
   end
 
-  # ── DML ───────────────────────────────────────────────────────────────────────
+  # DML
 
   @doc """
   Execute a DML or DDL statement.
@@ -206,7 +206,7 @@ defmodule ExArrow.FlightSQL.Client do
     impl().execute(client, sql, [])
   end
 
-  # ── Prepared statements ───────────────────────────────────────────────────────
+  # Prepared statements
 
   @doc """
   Prepare a SQL query on the server and return a reusable statement handle.
@@ -261,7 +261,7 @@ defmodule ExArrow.FlightSQL.Client do
     impl().prepare(client, sql, [])
   end
 
-  # ── Metadata ─────────────────────────────────────────────────────────────────
+  # Metadata
 
   @doc """
   List tables visible to the connected user.
@@ -281,12 +281,12 @@ defmodule ExArrow.FlightSQL.Client do
 
   ## Options
 
-  - `:catalog` — filter by exact catalog name (default: no filter)
-  - `:db_schema_filter` — SQL `LIKE` pattern for schema names (default: no filter)
-  - `:table_name_filter` — SQL `LIKE` pattern for table names (default: no filter)
-  - `:table_types` — list of type strings to include, e.g. `["TABLE", "VIEW"]`
+  - `:catalog`: filter by exact catalog name (default: no filter)
+  - `:db_schema_filter`: SQL `LIKE` pattern for schema names (default: no filter)
+  - `:table_name_filter`: SQL `LIKE` pattern for table names (default: no filter)
+  - `:table_types`: list of type strings to include, e.g. `["TABLE", "VIEW"]`
     (default: all types)
-  - `:include_schema` — `true` to include IPC-encoded column schema in results
+  - `:include_schema`: `true` to include IPC-encoded column schema in results
     (default: `false`)
 
   ## Server compatibility
@@ -323,8 +323,8 @@ defmodule ExArrow.FlightSQL.Client do
 
   ## Options
 
-  - `:catalog` — filter by exact catalog name (default: no filter)
-  - `:db_schema_filter` — SQL `LIKE` pattern for schema names (default: no filter)
+  - `:catalog`: filter by exact catalog name (default: no filter)
+  - `:db_schema_filter`: SQL `LIKE` pattern for schema names (default: no filter)
 
   ## Server compatibility
 
@@ -354,7 +354,7 @@ defmodule ExArrow.FlightSQL.Client do
   | Column | Type | Description |
   |--------|------|-------------|
   | `info_name` | `uint32` | Numeric `SqlInfo` code |
-  | `value` | `dense_union(...)` | Value — type depends on the info code |
+  | `value` | `dense_union(...)` | Value: type depends on the info code |
 
   All available `SqlInfo` entries are returned.  The exact set depends on the
   server; not all servers expose all codes.

--- a/lib/ex_arrow/flight_sql/client.ex
+++ b/lib/ex_arrow/flight_sql/client.ex
@@ -229,17 +229,28 @@ defmodule ExArrow.FlightSQL.Client do
   Servers that do not implement `CreatePreparedStatement` return
   `{:error, %Error{code: :unimplemented}}`.
 
-  Parameter binding (passing `?` placeholders with Arrow data) is not
-  supported in v0.5.0.
+  Use `ExArrow.FlightSQL.Statement.bind/2` to bind Arrow RecordBatch
+  parameters before executing.  Use `ExArrow.FlightSQL.Statement.close/1`
+  to release server-side resources when done.
 
   ## Examples
 
-      {:ok, stmt} = ExArrow.FlightSQL.Client.prepare(client, "SELECT * FROM t")
+      {:ok, stmt} = ExArrow.FlightSQL.Client.prepare(client, "SELECT * FROM t WHERE id = ?")
       {:ok, stream} = ExArrow.FlightSQL.Statement.execute(stmt)
       batches = Enum.to_list(stream)
 
-      # Re-execute the same statement without re-preparing
+      # Bind parameters and execute
+      params = ExArrow.RecordBatch.from_columns(["id"], [<<42::little-signed-64>>], ["int64"], 1)
+      :ok = ExArrow.FlightSQL.Statement.bind(stmt, params)
+      {:ok, stream} = ExArrow.FlightSQL.Statement.execute(stmt)
+
+      # Re-bind and re-execute (same statement, different parameters)
+      other_params = ExArrow.RecordBatch.from_columns(["id"], [<<99::little-signed-64>>], ["int64"], 1)
+      :ok = ExArrow.FlightSQL.Statement.bind(stmt, other_params)
       {:ok, stream2} = ExArrow.FlightSQL.Statement.execute(stmt)
+
+      # Close when done
+      :ok = ExArrow.FlightSQL.Statement.close(stmt)
   """
   @spec prepare(t(), String.t()) :: {:ok, Statement.t()} | {:error, Error.t()}
   def prepare(%__MODULE__{} = client, sql) when is_binary(sql) do

--- a/lib/ex_arrow/flight_sql/client.ex
+++ b/lib/ex_arrow/flight_sql/client.ex
@@ -240,12 +240,16 @@ defmodule ExArrow.FlightSQL.Client do
       batches = Enum.to_list(stream)
 
       # Bind parameters and execute
-      params = ExArrow.RecordBatch.from_columns(["id"], [<<42::little-signed-64>>], ["int64"], 1)
+      {:ok, params} =
+        ExArrow.RecordBatch.from_columns(["id"], [<<42::little-signed-64>>], ["s64"], 1)
+
       :ok = ExArrow.FlightSQL.Statement.bind(stmt, params)
       {:ok, stream} = ExArrow.FlightSQL.Statement.execute(stmt)
 
       # Re-bind and re-execute (same statement, different parameters)
-      other_params = ExArrow.RecordBatch.from_columns(["id"], [<<99::little-signed-64>>], ["int64"], 1)
+      {:ok, other_params} =
+        ExArrow.RecordBatch.from_columns(["id"], [<<99::little-signed-64>>], ["s64"], 1)
+
       :ok = ExArrow.FlightSQL.Statement.bind(stmt, other_params)
       {:ok, stream2} = ExArrow.FlightSQL.Statement.execute(stmt)
 

--- a/lib/ex_arrow/flight_sql/statement.ex
+++ b/lib/ex_arrow/flight_sql/statement.ex
@@ -35,7 +35,9 @@ defmodule ExArrow.FlightSQL.Statement do
   names; column types must be compatible.
 
   Use `parameter_schema/1` to inspect the expected parameter schema before
-  binding.
+  binding.  See `ExArrow.RecordBatch` for the full set of dtype strings
+  supported by `ExArrow.RecordBatch.from_columns/4`, including primitives,
+  date/timestamp/duration, and `utf8`/`binary` variants.
 
   ## Close semantics
 
@@ -49,9 +51,10 @@ defmodule ExArrow.FlightSQL.Statement do
   returns `:ok`.
 
   If `close/1` returns `{:error, ...}` (for example a transport error mid-
-  call), the statement handle is still consumed locally — retrying `close/1`
+  call) the statement handle is still consumed locally — retrying `close/1`
   is a no-op and returns `:ok`, but the server-side resource may not have
-  been released.
+  been released and can leak until the underlying connection is closed.
+  See `close/1` for details.
 
   ## Compatibility
 
@@ -169,20 +172,48 @@ defmodule ExArrow.FlightSQL.Statement do
   Close the prepared statement and release server-side resources.
 
   Sends `ActionClosePreparedStatement` to the server.  Closed-state is
-  tracked inside the underlying NIF resource: after `close/1` returns
-  `:ok`, any subsequent call to `bind/2`, `execute/1`, `execute_update/1`,
-  or `parameter_schema/1` returns `{:error, %Error{code: :protocol_error}}`.
+  tracked inside the underlying NIF resource: after `close/1` returns,
+  any subsequent call to `bind/2`, `execute/1`, `execute_update/1`, or
+  `parameter_schema/1` returns `{:error, %Error{code: :protocol_error}}`.
 
   Close is idempotent: calling `close/1` on an already-closed statement
   returns `:ok` without contacting the server.
 
-  Returns `:ok` on success or `{:error, %Error{}}` on failure.  On
-  failure the statement handle is still consumed locally — subsequent
-  operations will return `:protocol_error`.
+  ## Return values
+
+  - `:ok` — the server acknowledged `ActionClosePreparedStatement` and
+    released the resource.
+  - `{:error, %Error{}}` — a transport, protocol, or server error
+    occurred while closing.
+
+  ## Behaviour on error
+
+  The underlying `arrow-flight` `PreparedStatement::close(self)` consumes
+  the statement value, so retrying after a failure is not possible.  When
+  `close/1` returns `{:error, ...}`:
+
+  - The statement handle is consumed locally regardless of outcome.
+  - All subsequent operations on the handle (including a retry of
+    `close/1`) return `:ok` for `close/1` and `:protocol_error` for
+    everything else.
+  - The server-side resource may or may not have been freed.  If the
+    failure was transient (for example a transport error mid-call) the
+    server-side prepared statement may leak until the connection is
+    closed.
+
+  Callers that need a guarantee of server-side cleanup should drop the
+  whole client connection on a `close/1` error.
 
   ## Examples
 
       :ok = ExArrow.FlightSQL.Statement.close(stmt)
+
+      # Defensive cleanup pattern
+      try do
+        # ... use stmt ...
+      after
+        _ = ExArrow.FlightSQL.Statement.close(stmt)
+      end
   """
   @spec close(t()) :: :ok | {:error, Error.t()}
   def close(%__MODULE__{resource: ref}) do

--- a/lib/ex_arrow/flight_sql/statement.ex
+++ b/lib/ex_arrow/flight_sql/statement.ex
@@ -7,10 +7,13 @@ defmodule ExArrow.FlightSQL.Statement do
 
   ## Lifecycle
 
-      {:ok, stmt} = ExArrow.FlightSQL.Client.prepare(client, "SELECT * FROM users WHERE id = ?")
+      {:ok, stmt} =
+        ExArrow.FlightSQL.Client.prepare(client, "SELECT * FROM users WHERE id = ?")
 
       # Bind parameters
-      params = ExArrow.RecordBatch.from_columns(["id"], [<<123::little-signed-64>>], ["int64"], 1)
+      {:ok, params} =
+        ExArrow.RecordBatch.from_columns(["id"], [<<123::little-signed-64>>], ["s64"], 1)
+
       :ok = ExArrow.FlightSQL.Statement.bind(stmt, params)
 
       # Execute
@@ -37,12 +40,18 @@ defmodule ExArrow.FlightSQL.Statement do
   ## Close semantics
 
   `close/1` sends `ActionClosePreparedStatement` to the server, releasing
-  server-side resources.  After closing, any subsequent call to `bind/2`,
-  `execute/1`, `execute_update/1`, or `close/1` returns
+  server-side resources.  Closed-state is tracked inside the underlying NIF
+  resource; after `close/1` returns `:ok`, any subsequent call to `bind/2`,
+  `execute/1`, `execute_update/1`, or `parameter_schema/1` returns
   `{:error, %Error{code: :protocol_error, message: "statement is closed"}}`.
 
   Close is idempotent: calling `close/1` on an already-closed statement
   returns `:ok`.
+
+  If `close/1` returns `{:error, ...}` (for example a transport error mid-
+  call), the statement handle is still consumed locally — retrying `close/1`
+  is a no-op and returns `:ok`, but the server-side resource may not have
+  been released.
 
   ## Compatibility
 
@@ -55,12 +64,9 @@ defmodule ExArrow.FlightSQL.Statement do
   alias ExArrow.FlightSQL.Error
   alias ExArrow.{RecordBatch, Schema, Stream}
 
-  @opaque t :: %__MODULE__{
-            resource: reference(),
-            closed: boolean()
-          }
+  @opaque t :: %__MODULE__{resource: reference()}
 
-  defstruct [:resource, closed: false]
+  defstruct [:resource]
 
   @doc """
   Bind a `RecordBatch` of parameters to the prepared statement.
@@ -73,18 +79,17 @@ defmodule ExArrow.FlightSQL.Statement do
   Binding replaces any previously bound parameters.  After binding, call
   `execute/1` or `execute_update/1` to run the statement with the parameters.
 
-  Returns `:ok` on success or `{:error, %Error{}}` on failure.
+  Returns `:ok` on success or `{:error, %Error{}}` on failure (including
+  `:protocol_error` if the statement has been closed).
 
   ## Examples
 
-      params = ExArrow.RecordBatch.from_columns(["id"], [<<42::little-signed-64>>], ["int64"], 1)
+      {:ok, params} =
+        ExArrow.RecordBatch.from_columns(["id"], [<<42::little-signed-64>>], ["s64"], 1)
+
       :ok = ExArrow.FlightSQL.Statement.bind(stmt, params)
   """
   @spec bind(t(), RecordBatch.t()) :: :ok | {:error, Error.t()}
-  def bind(%__MODULE__{resource: _ref, closed: true}, _batch) do
-    {:error, Error.from_string(:protocol_error, "statement is closed")}
-  end
-
   def bind(%__MODULE__{resource: ref}, %RecordBatch{resource: batch_ref}) do
     case native().flight_sql_prepared_bind(ref, batch_ref) do
       :ok -> :ok
@@ -98,7 +103,8 @@ defmodule ExArrow.FlightSQL.Statement do
   The schema describes the column names and Arrow types that `bind/2`
   expects.  An empty schema means the statement takes no parameters.
 
-  Returns `{:ok, %ExArrow.Schema{}}` or `{:error, %Error{}}`.
+  Returns `{:ok, %ExArrow.Schema{}}` or `{:error, %Error{}}` (including
+  `:protocol_error` if the statement has been closed).
 
   ## Examples
 
@@ -106,10 +112,6 @@ defmodule ExArrow.FlightSQL.Statement do
       [%ExArrow.Field{name: "id", dtype: "int64"}] = ExArrow.Schema.fields(schema)
   """
   @spec parameter_schema(t()) :: {:ok, Schema.t()} | {:error, Error.t()}
-  def parameter_schema(%__MODULE__{resource: _ref, closed: true}) do
-    {:error, Error.from_string(:protocol_error, "statement is closed")}
-  end
-
   def parameter_schema(%__MODULE__{resource: ref}) do
     case native().flight_sql_prepared_parameter_schema(ref) do
       {:ok, schema_ref} -> {:ok, Schema.from_ref(schema_ref)}
@@ -124,7 +126,8 @@ defmodule ExArrow.FlightSQL.Statement do
   on the returned endpoint.  If parameters were bound with `bind/2`, they
   are sent to the server as part of the execution.
 
-  Returns `{:ok, %ExArrow.Stream{}}` or `{:error, %ExArrow.FlightSQL.Error{}}`.
+  Returns `{:ok, %ExArrow.Stream{}}` or `{:error, %ExArrow.FlightSQL.Error{}}`
+  (including `:protocol_error` if the statement has been closed).
 
   ## Examples
 
@@ -132,10 +135,6 @@ defmodule ExArrow.FlightSQL.Statement do
       batches = Enum.to_list(stream)
   """
   @spec execute(t()) :: {:ok, Stream.t()} | {:error, Error.t()}
-  def execute(%__MODULE__{resource: _ref, closed: true}) do
-    {:error, Error.from_string(:protocol_error, "statement is closed")}
-  end
-
   def execute(%__MODULE__{resource: ref}) do
     case native().flight_sql_prepared_execute(ref) do
       {:ok, stream_ref} -> {:ok, %Stream{resource: stream_ref, backend: :flight_sql}}
@@ -149,7 +148,8 @@ defmodule ExArrow.FlightSQL.Statement do
   Returns `{:ok, n}` where `n` is the number of affected rows, or
   `{:ok, :unknown}` when the server does not report a count.
 
-  Returns `{:error, %ExArrow.FlightSQL.Error{}}` on failure.
+  Returns `{:error, %ExArrow.FlightSQL.Error{}}` on failure (including
+  `:protocol_error` if the statement has been closed).
 
   ## Examples
 
@@ -157,10 +157,6 @@ defmodule ExArrow.FlightSQL.Statement do
       {:ok, 1} = ExArrow.FlightSQL.Statement.execute_update(stmt)
   """
   @spec execute_update(t()) :: {:ok, non_neg_integer() | :unknown} | {:error, Error.t()}
-  def execute_update(%__MODULE__{resource: _ref, closed: true}) do
-    {:error, Error.from_string(:protocol_error, "statement is closed")}
-  end
-
   def execute_update(%__MODULE__{resource: ref}) do
     case native().flight_sql_prepared_execute_update(ref) do
       {:ok, :unknown} -> {:ok, :unknown}
@@ -172,34 +168,28 @@ defmodule ExArrow.FlightSQL.Statement do
   @doc """
   Close the prepared statement and release server-side resources.
 
-  Sends `ActionClosePreparedStatement` to the server.  After closing, any
-  subsequent calls to `bind/2`, `execute/1`, `execute_update/1`, or
-  `close/1` return `{:error, %Error{code: :protocol_error}}`.
+  Sends `ActionClosePreparedStatement` to the server.  Closed-state is
+  tracked inside the underlying NIF resource: after `close/1` returns
+  `:ok`, any subsequent call to `bind/2`, `execute/1`, `execute_update/1`,
+  or `parameter_schema/1` returns `{:error, %Error{code: :protocol_error}}`.
 
   Close is idempotent: calling `close/1` on an already-closed statement
-  returns `:ok`.
+  returns `:ok` without contacting the server.
 
-  Returns `:ok` on success or `{:error, %Error{}}` on failure.
+  Returns `:ok` on success or `{:error, %Error{}}` on failure.  On
+  failure the statement handle is still consumed locally — subsequent
+  operations will return `:protocol_error`.
 
   ## Examples
 
       :ok = ExArrow.FlightSQL.Statement.close(stmt)
   """
   @spec close(t()) :: :ok | {:error, Error.t()}
-  def close(%__MODULE__{closed: true}), do: :ok
-
-  def close(%__MODULE__{resource: ref} = stmt) do
-    result =
-      case native().flight_sql_prepared_close(ref) do
-        :ok -> :ok
-        {:error, nif_err} -> {:error, wrap_nif_error(nif_err)}
-      end
-
-    if result == :ok do
-      %{stmt | closed: true}
+  def close(%__MODULE__{resource: ref}) do
+    case native().flight_sql_prepared_close(ref) do
+      :ok -> :ok
+      {:error, nif_err} -> {:error, wrap_nif_error(nif_err)}
     end
-
-    result
   end
 
   # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/lib/ex_arrow/flight_sql/statement.ex
+++ b/lib/ex_arrow/flight_sql/statement.ex
@@ -51,7 +51,7 @@ defmodule ExArrow.FlightSQL.Statement do
   returns `:ok`.
 
   If `close/1` returns `{:error, ...}` (for example a transport error mid-
-  call) the statement handle is still consumed locally — retrying `close/1`
+  call) the statement handle is still consumed locally; retrying `close/1`
   is a no-op and returns `:ok`, but the server-side resource may not have
   been released and can leak until the underlying connection is closed.
   See `close/1` for details.
@@ -82,7 +82,7 @@ defmodule ExArrow.FlightSQL.Statement do
   Binding replaces any previously bound parameters.  After binding, call
   `execute/1` or `execute_update/1` to run the statement with the parameters.
 
-  Returns `:ok` on success or `{:error, %Error{}}` on failure (including
+  Succeeds with `:ok`, or fails with `{:error, %Error{}}` (including
   `:protocol_error` if the statement has been closed).
 
   ## Examples
@@ -106,13 +106,15 @@ defmodule ExArrow.FlightSQL.Statement do
   The schema describes the column names and Arrow types that `bind/2`
   expects.  An empty schema means the statement takes no parameters.
 
-  Returns `{:ok, %ExArrow.Schema{}}` or `{:error, %Error{}}` (including
-  `:protocol_error` if the statement has been closed).
+  The schema is returned as `{:ok, %ExArrow.Schema{}}`.  Fails with
+  `{:error, %Error{}}` on a closed handle (`:protocol_error`) or transport
+  error.
 
   ## Examples
 
       {:ok, schema} = ExArrow.FlightSQL.Statement.parameter_schema(stmt)
-      [%ExArrow.Field{name: "id", dtype: "int64"}] = ExArrow.Schema.fields(schema)
+      [%ExArrow.Field{name: "id", type: :int64, nullable: _}] =
+        ExArrow.Schema.fields(schema)
   """
   @spec parameter_schema(t()) :: {:ok, Schema.t()} | {:error, Error.t()}
   def parameter_schema(%__MODULE__{resource: ref}) do
@@ -129,8 +131,9 @@ defmodule ExArrow.FlightSQL.Statement do
   on the returned endpoint.  If parameters were bound with `bind/2`, they
   are sent to the server as part of the execution.
 
-  Returns `{:ok, %ExArrow.Stream{}}` or `{:error, %ExArrow.FlightSQL.Error{}}`
-  (including `:protocol_error` if the statement has been closed).
+  Yields `{:ok, %ExArrow.Stream{}}` for lazy iteration, or
+  `{:error, %ExArrow.FlightSQL.Error{}}` on failure (including
+  `:protocol_error` if the statement has been closed).
 
   ## Examples
 
@@ -150,9 +153,8 @@ defmodule ExArrow.FlightSQL.Statement do
 
   Returns `{:ok, n}` where `n` is the number of affected rows, or
   `{:ok, :unknown}` when the server does not report a count.
-
-  Returns `{:error, %ExArrow.FlightSQL.Error{}}` on failure (including
-  `:protocol_error` if the statement has been closed).
+  Fails with `{:error, %ExArrow.FlightSQL.Error{}}` on a closed handle
+  or other error.
 
   ## Examples
 
@@ -181,9 +183,8 @@ defmodule ExArrow.FlightSQL.Statement do
 
   ## Return values
 
-  - `:ok` — the server acknowledged `ActionClosePreparedStatement` and
-    released the resource.
-  - `{:error, %Error{}}` — a transport, protocol, or server error
+  - `:ok`: the server acknowledged `ActionClosePreparedStatement` and released the resource.
+  - `{:error, %Error{}}`: a transport, protocol, or server error
     occurred while closing.
 
   ## Behaviour on error
@@ -223,7 +224,7 @@ defmodule ExArrow.FlightSQL.Statement do
     end
   end
 
-  # ── Helpers ───────────────────────────────────────────────────────────────────
+  # Helpers
 
   defp native,
     do: Application.get_env(:ex_arrow, :flight_sql_statement_native, ExArrow.Native)

--- a/lib/ex_arrow/flight_sql/statement.ex
+++ b/lib/ex_arrow/flight_sql/statement.ex
@@ -3,32 +3,46 @@ defmodule ExArrow.FlightSQL.Statement do
   An opaque handle to a server-side prepared statement.
 
   A `Statement` is created by `ExArrow.FlightSQL.Client.prepare/2` and
-  represents a query that has been parsed and planned on the server.  The
-  same statement can be executed multiple times.
-
-  ## Usage
-
-      {:ok, stmt} = ExArrow.FlightSQL.Client.prepare(client, "SELECT * FROM t WHERE ts > '2024-01-01'")
-
-      # Execute as a streaming query
-      {:ok, stream} = ExArrow.FlightSQL.Statement.execute(stmt)
-      batches = Enum.to_list(stream)
-
-      # Execute again (reuses the server-side plan)
-      {:ok, stream2} = ExArrow.FlightSQL.Statement.execute(stmt)
+  represents a query that has been parsed and planned on the server.
 
   ## Lifecycle
 
-  The underlying server-side handle is released when the `Statement` struct
-  is garbage-collected.  There is no explicit `close/1` in v0.5.0; dropping
-  the struct is sufficient.
+      {:ok, stmt} = ExArrow.FlightSQL.Client.prepare(client, "SELECT * FROM users WHERE id = ?")
+
+      # Bind parameters
+      params = ExArrow.RecordBatch.from_columns(["id"], [<<123::little-signed-64>>], ["int64"], 1)
+      :ok = ExArrow.FlightSQL.Statement.bind(stmt, params)
+
+      # Execute
+      {:ok, stream} = ExArrow.FlightSQL.Statement.execute(stmt)
+      batches = Enum.to_list(stream)
+
+      # Re-bind and re-execute
+      :ok = ExArrow.FlightSQL.Statement.bind(stmt, other_params)
+      {:ok, stream2} = ExArrow.FlightSQL.Statement.execute(stmt)
+
+      # Close when done
+      :ok = ExArrow.FlightSQL.Statement.close(stmt)
 
   ## Parameter binding
 
-  Parameter binding is not supported in v0.5.0.  Statements are executed
-  with no bound parameters.  Parameterized queries (`SELECT * FROM t WHERE id = ?`)
-  can be prepared and executed, but the parameter values cannot be set from
-  Elixir in this release.
+  Parameters are bound as Arrow `RecordBatch` values using `bind/2`.  The
+  batch schema must be compatible with the parameter schema returned by the
+  server during `CreatePreparedStatement`.  Column names must match parameter
+  names; column types must be compatible.
+
+  Use `parameter_schema/1` to inspect the expected parameter schema before
+  binding.
+
+  ## Close semantics
+
+  `close/1` sends `ActionClosePreparedStatement` to the server, releasing
+  server-side resources.  After closing, any subsequent call to `bind/2`,
+  `execute/1`, `execute_update/1`, or `close/1` returns
+  `{:error, %Error{code: :protocol_error, message: "statement is closed"}}`.
+
+  Close is idempotent: calling `close/1` on an already-closed statement
+  returns `:ok`.
 
   ## Compatibility
 
@@ -39,16 +53,76 @@ defmodule ExArrow.FlightSQL.Statement do
   """
 
   alias ExArrow.FlightSQL.Error
-  alias ExArrow.Stream
+  alias ExArrow.{RecordBatch, Schema, Stream}
 
-  @opaque t :: %__MODULE__{resource: reference()}
-  defstruct [:resource]
+  @opaque t :: %__MODULE__{
+            resource: reference(),
+            closed: boolean()
+          }
+
+  defstruct [:resource, closed: false]
+
+  @doc """
+  Bind a `RecordBatch` of parameters to the prepared statement.
+
+  The batch must match the parameter schema returned by the server.  Column
+  names must correspond to the `?` placeholders in the SQL query; column
+  types must be compatible Arrow types.  Use `parameter_schema/1` to inspect
+  the expected schema.
+
+  Binding replaces any previously bound parameters.  After binding, call
+  `execute/1` or `execute_update/1` to run the statement with the parameters.
+
+  Returns `:ok` on success or `{:error, %Error{}}` on failure.
+
+  ## Examples
+
+      params = ExArrow.RecordBatch.from_columns(["id"], [<<42::little-signed-64>>], ["int64"], 1)
+      :ok = ExArrow.FlightSQL.Statement.bind(stmt, params)
+  """
+  @spec bind(t(), RecordBatch.t()) :: :ok | {:error, Error.t()}
+  def bind(%__MODULE__{resource: _ref, closed: true}, _batch) do
+    {:error, Error.from_string(:protocol_error, "statement is closed")}
+  end
+
+  def bind(%__MODULE__{resource: ref}, %RecordBatch{resource: batch_ref}) do
+    case native().flight_sql_prepared_bind(ref, batch_ref) do
+      :ok -> :ok
+      {:error, nif_err} -> {:error, wrap_nif_error(nif_err)}
+    end
+  end
+
+  @doc """
+  Return the parameter schema of the prepared statement.
+
+  The schema describes the column names and Arrow types that `bind/2`
+  expects.  An empty schema means the statement takes no parameters.
+
+  Returns `{:ok, %ExArrow.Schema{}}` or `{:error, %Error{}}`.
+
+  ## Examples
+
+      {:ok, schema} = ExArrow.FlightSQL.Statement.parameter_schema(stmt)
+      [%ExArrow.Field{name: "id", dtype: "int64"}] = ExArrow.Schema.fields(schema)
+  """
+  @spec parameter_schema(t()) :: {:ok, Schema.t()} | {:error, Error.t()}
+  def parameter_schema(%__MODULE__{resource: _ref, closed: true}) do
+    {:error, Error.from_string(:protocol_error, "statement is closed")}
+  end
+
+  def parameter_schema(%__MODULE__{resource: ref}) do
+    case native().flight_sql_prepared_parameter_schema(ref) do
+      {:ok, schema_ref} -> {:ok, Schema.from_ref(schema_ref)}
+      {:error, nif_err} -> {:error, wrap_nif_error(nif_err)}
+    end
+  end
 
   @doc """
   Execute the prepared statement and return a lazy record-batch stream.
 
   Sends `ExecutePreparedStatement` to the server and opens a `DoGet` stream
-  on the returned endpoint.
+  on the returned endpoint.  If parameters were bound with `bind/2`, they
+  are sent to the server as part of the execution.
 
   Returns `{:ok, %ExArrow.Stream{}}` or `{:error, %ExArrow.FlightSQL.Error{}}`.
 
@@ -58,6 +132,10 @@ defmodule ExArrow.FlightSQL.Statement do
       batches = Enum.to_list(stream)
   """
   @spec execute(t()) :: {:ok, Stream.t()} | {:error, Error.t()}
+  def execute(%__MODULE__{resource: _ref, closed: true}) do
+    {:error, Error.from_string(:protocol_error, "statement is closed")}
+  end
+
   def execute(%__MODULE__{resource: ref}) do
     case native().flight_sql_prepared_execute(ref) do
       {:ok, stream_ref} -> {:ok, %Stream{resource: stream_ref, backend: :flight_sql}}
@@ -75,16 +153,53 @@ defmodule ExArrow.FlightSQL.Statement do
 
   ## Examples
 
-      {:ok, stmt}    = ExArrow.FlightSQL.Client.prepare(client, "DELETE FROM t WHERE id = 42")
-      {:ok, 1}       = ExArrow.FlightSQL.Statement.execute_update(stmt)
+      {:ok, stmt} = ExArrow.FlightSQL.Client.prepare(client, "DELETE FROM t WHERE id = 42")
+      {:ok, 1} = ExArrow.FlightSQL.Statement.execute_update(stmt)
   """
   @spec execute_update(t()) :: {:ok, non_neg_integer() | :unknown} | {:error, Error.t()}
+  def execute_update(%__MODULE__{resource: _ref, closed: true}) do
+    {:error, Error.from_string(:protocol_error, "statement is closed")}
+  end
+
   def execute_update(%__MODULE__{resource: ref}) do
     case native().flight_sql_prepared_execute_update(ref) do
       {:ok, :unknown} -> {:ok, :unknown}
       {:ok, n} when is_integer(n) -> {:ok, n}
       {:error, nif_err} -> {:error, wrap_nif_error(nif_err)}
     end
+  end
+
+  @doc """
+  Close the prepared statement and release server-side resources.
+
+  Sends `ActionClosePreparedStatement` to the server.  After closing, any
+  subsequent calls to `bind/2`, `execute/1`, `execute_update/1`, or
+  `close/1` return `{:error, %Error{code: :protocol_error}}`.
+
+  Close is idempotent: calling `close/1` on an already-closed statement
+  returns `:ok`.
+
+  Returns `:ok` on success or `{:error, %Error{}}` on failure.
+
+  ## Examples
+
+      :ok = ExArrow.FlightSQL.Statement.close(stmt)
+  """
+  @spec close(t()) :: :ok | {:error, Error.t()}
+  def close(%__MODULE__{closed: true}), do: :ok
+
+  def close(%__MODULE__{resource: ref} = stmt) do
+    result =
+      case native().flight_sql_prepared_close(ref) do
+        :ok -> :ok
+        {:error, nif_err} -> {:error, wrap_nif_error(nif_err)}
+      end
+
+    if result == :ok do
+      %{stmt | closed: true}
+    end
+
+    result
   end
 
   # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/lib/ex_arrow/native.ex
+++ b/lib/ex_arrow/native.ex
@@ -183,5 +183,13 @@ defmodule ExArrow.Native do
   def flight_sql_prepared_execute_update(_stmt_ref),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  def flight_sql_prepared_bind(_stmt_ref, _batch_ref),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def flight_sql_prepared_parameter_schema(_stmt_ref),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def flight_sql_prepared_close(_stmt_ref), do: :erlang.nif_error(:nif_not_loaded)
+
   # coveralls-ignore-stop
 end

--- a/lib/ex_arrow/record_batch.ex
+++ b/lib/ex_arrow/record_batch.ex
@@ -3,7 +3,7 @@ defmodule ExArrow.RecordBatch do
   Arrow record batch handle (opaque reference to native record batch).
 
   A batch is a collection of column arrays with a shared schema and row count.
-  It sits between `ExArrow.Array` (one column) and `ExArrow.Table` or 
+  It sits between `ExArrow.Array` (one column) and `ExArrow.Table` or
   `ExArrow.Stream` (multiple batches).  Data stays in native memory; accessors
   return handles or small metadata.
 
@@ -14,6 +14,82 @@ defmodule ExArrow.RecordBatch do
       RecordBatch ── Array (one per column)
                         │
       Table / Stream ── RecordBatch (one or more)
+
+  ## Supported dtype strings (`from_columns/4`)
+
+  The `from_columns/4` constructor accepts a per-column dtype string.  The
+  full set of supported strings, the corresponding Arrow logical type, and
+  the wire format expected for each column binary are listed below.
+
+  ### Fixed-width primitives
+
+  Each column binary is exactly `length × element_size` bytes, in
+  little-endian byte order for multi-byte types.
+
+  | dtype  | Arrow type         | element size |
+  |--------|--------------------|--------------|
+  | `"s8"`  | `Int8`             | 1 byte       |
+  | `"s16"` | `Int16`            | 2 bytes      |
+  | `"s32"` | `Int32`            | 4 bytes      |
+  | `"s64"` | `Int64`            | 8 bytes      |
+  | `"u8"`  | `UInt8`            | 1 byte       |
+  | `"u16"` | `UInt16`           | 2 bytes      |
+  | `"u32"` | `UInt32`           | 4 bytes      |
+  | `"u64"` | `UInt64`           | 8 bytes      |
+  | `"f32"` | `Float32`          | 4 bytes      |
+  | `"f64"` | `Float64`          | 8 bytes      |
+
+  ### Boolean
+
+  `"bool"` — exactly `length` bytes, one byte per element (0 = false,
+  non-zero = true).
+
+  ### Date and time
+
+  Dates are days or milliseconds since 1970-01-01.  Timestamps are ticks
+  since the Unix epoch in UTC.  Durations are tick counts.  All temporal
+  types are little-endian.
+
+  | dtype  | Arrow type | Rust scalar | element size |
+  |--------|------------|-------------|--------------|
+  | `"date32"`              | `Date32`                            | i32 days   | 4 bytes |
+  | `"date64"`              | `Date64`                            | i64 millis | 8 bytes |
+  | `"timestamp_seconds"`   | `Timestamp(Second, None)`           | i64 sec    | 8 bytes |
+  | `"timestamp_millis"`    | `Timestamp(Millisecond, None)`      | i64 ms     | 8 bytes |
+  | `"timestamp_micros"`    | `Timestamp(Microsecond, None)`      | i64 µs     | 8 bytes |
+  | `"timestamp_nanos"`     | `Timestamp(Nanosecond, None)`       | i64 ns     | 8 bytes |
+  | `"duration_seconds"`    | `Duration(Second)`                  | i64 sec    | 8 bytes |
+  | `"duration_millis"`     | `Duration(Millisecond)`             | i64 ms     | 8 bytes |
+  | `"duration_micros"`     | `Duration(Microsecond)`             | i64 µs     | 8 bytes |
+  | `"duration_nanos"`      | `Duration(Nanosecond)`              | i64 ns     | 8 bytes |
+
+  Timestamps are emitted with no timezone (`None`).  The caller is
+  responsible for ensuring the i64 ticks are in UTC if the consuming
+  server treats the column as zoned.
+
+  ### Variable-length string and binary
+
+  Variable-length columns use a length-prefixed wire format.  The column
+  binary is the concatenation of `length` records, each of the form:
+
+      <<elem_len::unsigned-little-32, elem_bytes::binary-size(elem_len)>>
+
+  | dtype           | Arrow type     |
+  |-----------------|----------------|
+  | `"utf8"`        | `Utf8`         |
+  | `"large_utf8"`  | `LargeUtf8`    |
+  | `"binary"`      | `Binary`       |
+  | `"large_binary"`| `LargeBinary`  |
+
+  `"utf8"` and `"large_utf8"` validate UTF-8 on the entire payload and
+  return `{:error, msg}` if any element is invalid.  `"binary"` and
+  `"large_binary"` accept arbitrary bytes.
+
+  ## Nullability
+
+  `from_columns/4` produces non-nullable columns (`Field.nullable = false`).
+  Pass nulls by binding a separate column or by using a parameter schema
+  that accepts non-null values only.
   """
   alias ExArrow.Native
   alias ExArrow.Schema
@@ -87,42 +163,27 @@ defmodule ExArrow.RecordBatch do
   @doc """
   Create a `RecordBatch` from column-oriented binary data.
 
-  Each column is provided as a raw little-endian binary, paired with an
-  Arrow dtype string and shared row count.  This is the primary constructor
-  for building parameter batches for Flight SQL prepared statement binding.
+  Each column is provided as a raw binary paired with an Arrow dtype
+  string and a shared row count.  This is the primary constructor for
+  building parameter batches for Flight SQL prepared statement binding.
 
   ## Parameters
 
   - `names` — list of column name strings
-  - `binaries` — list of raw column data binaries (little-endian for
-    integers and floats; one byte per element for `"bool"`)
-  - `dtypes` — list of Arrow dtype strings (see below)
+  - `binaries` — list of column data binaries (one per column).  See the
+    [supported dtypes](#module-supported-dtype-strings-from_columns-4)
+    table in the moduledoc for the wire format of each dtype.
+  - `dtypes` — list of Arrow dtype strings, one per column
   - `length` — number of rows (must be the same for every column)
 
-  ## Supported dtype strings
-
-  | dtype  | Arrow type | element size |
-  |--------|------------|--------------|
-  | `"s8"`  | Int8       | 1 byte       |
-  | `"s16"` | Int16      | 2 bytes      |
-  | `"s32"` | Int32      | 4 bytes      |
-  | `"s64"` | Int64      | 8 bytes      |
-  | `"u8"`  | UInt8      | 1 byte       |
-  | `"u16"` | UInt16     | 2 bytes      |
-  | `"u32"` | UInt32     | 4 bytes      |
-  | `"u64"` | UInt64     | 8 bytes      |
-  | `"f32"` | Float32    | 4 bytes      |
-  | `"f64"` | Float64    | 8 bytes      |
-  | `"bool"` | Boolean   | 1 byte (0 = false, non-zero = true) |
-
-  String, binary, date, timestamp, and duration types are not yet supported
-  by this constructor.
+  All four lists must have the same length and at least one entry.
 
   ## Returns
 
   - `{:ok, %ExArrow.RecordBatch{}}` on success
-  - `{:error, message}` if the inputs are inconsistent (mismatched lengths,
-    binary size doesn't match `length × element_size`, unknown dtype, etc.)
+  - `{:error, message}` if the inputs are inconsistent (mismatched
+    list lengths, malformed binary, unknown dtype, invalid UTF-8 in a
+    `"utf8"`/`"large_utf8"` column, etc.)
 
   ## Examples
 
@@ -134,13 +195,23 @@ defmodule ExArrow.RecordBatch do
         1
       )
 
-      # Multiple columns: int64 and float64
+      # Mixed primitives
       {:ok, batch} = ExArrow.RecordBatch.from_columns(
         ["id", "score"],
         [<<1::little-signed-64>>, <<3.14::little-float-64>>],
         ["s64", "f64"],
         1
       )
+
+      # utf8 column with two rows ("hello", "world") using length-prefixed
+      # records: <<len::little-32, bytes::binary-size(len)>>
+      utf8 = <<5::little-32, "hello", 5::little-32, "world">>
+      {:ok, batch} = ExArrow.RecordBatch.from_columns(["s"], [utf8], ["utf8"], 2)
+
+      # timestamp_micros column
+      ts = <<1_700_000_000_000_000::little-signed-64>>
+      {:ok, batch} =
+        ExArrow.RecordBatch.from_columns(["t"], [ts], ["timestamp_micros"], 1)
   """
   @spec from_columns([String.t()], [binary()], [String.t()], non_neg_integer()) ::
           {:ok, t()} | {:error, String.t()}

--- a/lib/ex_arrow/record_batch.ex
+++ b/lib/ex_arrow/record_batch.ex
@@ -78,10 +78,76 @@ defmodule ExArrow.RecordBatch do
       {:ok, ipc_bin} = ExArrow.Native.ipc_test_fixture_binary()
       {:ok, stream}  = ExArrow.IPC.Reader.from_binary(ipc_bin)
       batch = ExArrow.Stream.next(stream)
-      ExArrow.RecordBatch.column_names(batch)  #=> ["id", "name"]
   """
   @spec column_names(t()) :: [String.t()]
   def column_names(%__MODULE__{} = batch) do
     batch |> schema() |> Schema.field_names()
+  end
+
+  @doc """
+  Create a `RecordBatch` from column-oriented binary data.
+
+  This is the primary way to construct a `RecordBatch` for parameter binding
+  in Flight SQL prepared statements.  Each column is provided as a raw binary
+  in native Arrow IPC format, with a corresponding Arrow type string.
+
+  ## Parameters
+
+  - `names`  - list of column name strings
+  - `binaries` - list of raw column data binaries (little-endian for integers/floats)
+  - `dtypes` - list of Arrow type strings (e.g. `["int64", "utf8", "float64"]`)
+  - `length` - number of rows (must be consistent across all columns)
+
+  ## Supported Arrow type strings
+
+  Integer types: `"int8"`, `"int16"`, `"int32"`, `"int64"`,
+  `"uint8"`, `"uint16"`, `"uint32"`, `"uint64"`
+
+  Float types: `"float16"`, `"float32"`, `"float64"`
+
+  String types: `"utf8"`, `"large_utf8"`
+
+  Boolean: `"bool"`
+
+  Date/Time: `"date32"`, `"timestamp_seconds"`, `"timestamp_millis"`,
+  `"timestamp_micros"`, `"timestamp_nanos"`
+
+  Duration: `"duration_seconds"`, `"duration_millis"`,
+  `"duration_micros"`, `"duration_nanos"`
+
+  Binary: `"binary"`, `"large_binary"`
+
+  ## Examples
+
+      # Single int64 column with one row
+      batch = ExArrow.RecordBatch.from_columns(
+        ["id"],
+        [<<42::little-signed-64>>],
+        ["int64"],
+        1
+      )
+
+      # Multiple columns
+      batch = ExArrow.RecordBatch.from_columns(
+        ["id", "name"],
+        [<<1::little-signed-64>>, "Alice"],
+        ["int64", "utf8"],
+        1
+      )
+  """
+  @spec from_columns([String.t()], [binary()], [String.t()], non_neg_integer()) ::
+          t()
+  def from_columns(names, binaries, dtypes, length)
+      when is_list(names) and is_list(binaries) and is_list(dtypes) and
+             is_integer(length) and length >= 0 do
+    ref =
+      Native.record_batch_from_column_binaries(
+        names,
+        binaries,
+        dtypes,
+        length
+      )
+
+    %__MODULE__{resource: ref}
   end
 end

--- a/lib/ex_arrow/record_batch.ex
+++ b/lib/ex_arrow/record_batch.ex
@@ -41,7 +41,7 @@ defmodule ExArrow.RecordBatch do
 
   ### Boolean
 
-  `"bool"` — exactly `length` bytes, one byte per element (0 = false,
+  `"bool"`: exactly `length` bytes, one byte per element (0 = false,
   non-zero = true).
 
   ### Date and time
@@ -129,7 +129,7 @@ defmodule ExArrow.RecordBatch do
   @doc """
   Returns the number of columns in this batch.
 
-  Derived from the batch's schema — no separate NIF call is needed.
+  Derived from the batch's schema; no separate NIF call is needed.
 
   ## Examples
 
@@ -164,17 +164,16 @@ defmodule ExArrow.RecordBatch do
   Create a `RecordBatch` from column-oriented binary data.
 
   Each column is provided as a raw binary paired with an Arrow dtype
-  string and a shared row count.  This is the primary constructor for
-  building parameter batches for Flight SQL prepared statement binding.
+  string and a shared row count.  This constructor builds parameter batches for Flight SQL prepared statement binding.
 
   ## Parameters
 
-  - `names` — list of column name strings
-  - `binaries` — list of column data binaries (one per column).  See the
+  - `names`: list of column name strings
+  - `binaries`: list of column data binaries (one per column).  See the
     [supported dtypes](#module-supported-dtype-strings-from_columns-4)
     table in the moduledoc for the wire format of each dtype.
-  - `dtypes` — list of Arrow dtype strings, one per column
-  - `length` — number of rows (must be the same for every column)
+  - `dtypes`: list of Arrow dtype strings, one per column
+  - `length`: number of rows (must be the same for every column)
 
   All four lists must have the same length and at least one entry.
 

--- a/lib/ex_arrow/record_batch.ex
+++ b/lib/ex_arrow/record_batch.ex
@@ -87,67 +87,69 @@ defmodule ExArrow.RecordBatch do
   @doc """
   Create a `RecordBatch` from column-oriented binary data.
 
-  This is the primary way to construct a `RecordBatch` for parameter binding
-  in Flight SQL prepared statements.  Each column is provided as a raw binary
-  in native Arrow IPC format, with a corresponding Arrow type string.
+  Each column is provided as a raw little-endian binary, paired with an
+  Arrow dtype string and shared row count.  This is the primary constructor
+  for building parameter batches for Flight SQL prepared statement binding.
 
   ## Parameters
 
-  - `names`  - list of column name strings
-  - `binaries` - list of raw column data binaries (little-endian for integers/floats)
-  - `dtypes` - list of Arrow type strings (e.g. `["int64", "utf8", "float64"]`)
-  - `length` - number of rows (must be consistent across all columns)
+  - `names` — list of column name strings
+  - `binaries` — list of raw column data binaries (little-endian for
+    integers and floats; one byte per element for `"bool"`)
+  - `dtypes` — list of Arrow dtype strings (see below)
+  - `length` — number of rows (must be the same for every column)
 
-  ## Supported Arrow type strings
+  ## Supported dtype strings
 
-  Integer types: `"int8"`, `"int16"`, `"int32"`, `"int64"`,
-  `"uint8"`, `"uint16"`, `"uint32"`, `"uint64"`
+  | dtype  | Arrow type | element size |
+  |--------|------------|--------------|
+  | `"s8"`  | Int8       | 1 byte       |
+  | `"s16"` | Int16      | 2 bytes      |
+  | `"s32"` | Int32      | 4 bytes      |
+  | `"s64"` | Int64      | 8 bytes      |
+  | `"u8"`  | UInt8      | 1 byte       |
+  | `"u16"` | UInt16     | 2 bytes      |
+  | `"u32"` | UInt32     | 4 bytes      |
+  | `"u64"` | UInt64     | 8 bytes      |
+  | `"f32"` | Float32    | 4 bytes      |
+  | `"f64"` | Float64    | 8 bytes      |
+  | `"bool"` | Boolean   | 1 byte (0 = false, non-zero = true) |
 
-  Float types: `"float16"`, `"float32"`, `"float64"`
+  String, binary, date, timestamp, and duration types are not yet supported
+  by this constructor.
 
-  String types: `"utf8"`, `"large_utf8"`
+  ## Returns
 
-  Boolean: `"bool"`
-
-  Date/Time: `"date32"`, `"timestamp_seconds"`, `"timestamp_millis"`,
-  `"timestamp_micros"`, `"timestamp_nanos"`
-
-  Duration: `"duration_seconds"`, `"duration_millis"`,
-  `"duration_micros"`, `"duration_nanos"`
-
-  Binary: `"binary"`, `"large_binary"`
+  - `{:ok, %ExArrow.RecordBatch{}}` on success
+  - `{:error, message}` if the inputs are inconsistent (mismatched lengths,
+    binary size doesn't match `length × element_size`, unknown dtype, etc.)
 
   ## Examples
 
       # Single int64 column with one row
-      batch = ExArrow.RecordBatch.from_columns(
+      {:ok, batch} = ExArrow.RecordBatch.from_columns(
         ["id"],
         [<<42::little-signed-64>>],
-        ["int64"],
+        ["s64"],
         1
       )
 
-      # Multiple columns
-      batch = ExArrow.RecordBatch.from_columns(
-        ["id", "name"],
-        [<<1::little-signed-64>>, "Alice"],
-        ["int64", "utf8"],
+      # Multiple columns: int64 and float64
+      {:ok, batch} = ExArrow.RecordBatch.from_columns(
+        ["id", "score"],
+        [<<1::little-signed-64>>, <<3.14::little-float-64>>],
+        ["s64", "f64"],
         1
       )
   """
   @spec from_columns([String.t()], [binary()], [String.t()], non_neg_integer()) ::
-          t()
+          {:ok, t()} | {:error, String.t()}
   def from_columns(names, binaries, dtypes, length)
       when is_list(names) and is_list(binaries) and is_list(dtypes) and
              is_integer(length) and length >= 0 do
-    ref =
-      Native.record_batch_from_column_binaries(
-        names,
-        binaries,
-        dtypes,
-        length
-      )
-
-    %__MODULE__{resource: ref}
+    case Native.record_batch_from_column_binaries(names, binaries, dtypes, length) do
+      {:ok, ref} -> {:ok, %__MODULE__{resource: ref}}
+      {:error, _} = err -> err
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,6 @@ defmodule ExArrow.MixProject do
       package: package(),
       test_coverage: [tool: ExCoveralls],
       dialyzer: [
-        plt_file: {:no_warn, "priv/plts/project.plt"},
         plt_add_apps: [:mix],
         ignore_warnings: "dialyzer_ignore.exs"
       ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExArrow.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.6.1"
   @source_url "https://github.com/thanos/ex_arrow"
 
   def project do

--- a/native/ex_arrow_native/src/adbc.rs
+++ b/native/ex_arrow_native/src/adbc.rs
@@ -63,37 +63,72 @@ impl rustler::Resource for AdbcResultStream {}
 
 fn decode_driver_spec<'a>(term: Term<'a>) -> Result<DriverSpec, String> {
     if let Ok(path) = term.decode::<String>() {
-        return Ok(DriverSpec::Path { path, uri: None, db_path: None, entrypoint: None });
+        return Ok(DriverSpec::Path {
+            path,
+            uri: None,
+            db_path: None,
+            entrypoint: None,
+        });
     }
-    let list: rustler::types::list::ListIterator = term.decode().map_err(|_| "opts must be a list")?;
+    let list: rustler::types::list::ListIterator =
+        term.decode().map_err(|_| "opts must be a list")?;
     let mut driver_path_val = None;
     let mut driver_name_val = None;
     let mut uri_val = None;
     let mut db_path_val: Option<String> = None;
     let mut entrypoint_val: Option<String> = None;
     for item in list {
-        let tuple = rustler::types::tuple::get_tuple(item).map_err(|_| "opt must be {key, value}")?;
+        let tuple =
+            rustler::types::tuple::get_tuple(item).map_err(|_| "opt must be {key, value}")?;
         if tuple.len() != 2 {
             continue;
         }
         let key: rustler::Atom = tuple[0].decode().map_err(|_| "opt key must be atom")?;
         if key == driver_path() {
-            driver_path_val = Some(tuple[1].decode::<String>().map_err(|_| "driver_path must be string")?);
+            driver_path_val = Some(
+                tuple[1]
+                    .decode::<String>()
+                    .map_err(|_| "driver_path must be string")?,
+            );
         } else if key == driver_name() {
-            driver_name_val = Some(tuple[1].decode::<String>().map_err(|_| "driver_name must be string")?);
+            driver_name_val = Some(
+                tuple[1]
+                    .decode::<String>()
+                    .map_err(|_| "driver_name must be string")?,
+            );
         } else if key == uri() {
-            uri_val = Some(tuple[1].decode::<String>().map_err(|_| "uri must be string")?);
+            uri_val = Some(
+                tuple[1]
+                    .decode::<String>()
+                    .map_err(|_| "uri must be string")?,
+            );
         } else if key == path() {
             // Driver-specific database path (e.g. DuckDB uses "path", not "uri").
-            db_path_val = Some(tuple[1].decode::<String>().map_err(|_| "path must be string")?);
+            db_path_val = Some(
+                tuple[1]
+                    .decode::<String>()
+                    .map_err(|_| "path must be string")?,
+            );
         } else if key == entrypoint() {
-            entrypoint_val = Some(tuple[1].decode::<String>().map_err(|_| "entrypoint must be string")?);
+            entrypoint_val = Some(
+                tuple[1]
+                    .decode::<String>()
+                    .map_err(|_| "entrypoint must be string")?,
+            );
         }
     }
     if let Some(p) = driver_path_val {
-        Ok(DriverSpec::Path { path: p, uri: uri_val, db_path: db_path_val, entrypoint: entrypoint_val })
+        Ok(DriverSpec::Path {
+            path: p,
+            uri: uri_val,
+            db_path: db_path_val,
+            entrypoint: entrypoint_val,
+        })
     } else if let Some(n) = driver_name_val {
-        Ok(DriverSpec::Name { name: n, uri: uri_val })
+        Ok(DriverSpec::Name {
+            name: n,
+            uri: uri_val,
+        })
     } else {
         Err("opts must include driver_path or driver_name".to_string())
     }
@@ -101,12 +136,14 @@ fn decode_driver_spec<'a>(term: Term<'a>) -> Result<DriverSpec, String> {
 
 enum DriverSpec {
     /// path to .so; optional entrypoint (default: "AdbcDriverInit"); optional uri or db_path.
-    Path { path: String, uri: Option<String>, db_path: Option<String>, entrypoint: Option<String> },
-    /// name: driver library name; uri: only set when caller provides :uri (no default).
-    Name {
-        name: String,
+    Path {
+        path: String,
         uri: Option<String>,
+        db_path: Option<String>,
+        entrypoint: Option<String>,
     },
+    /// name: driver library name; uri: only set when caller provides :uri (no default).
+    Name { name: String, uri: Option<String> },
 }
 
 /// Open a database: load driver from path or by name (env), init database.
@@ -119,7 +156,12 @@ pub fn adbc_database_open<'a>(env: Env<'a>, driver_path_or_opts: Term<'a>) -> Te
     };
     let version = AdbcVersion::V100;
     let (driver, database) = match spec {
-        DriverSpec::Path { path, uri, db_path, entrypoint } => {
+        DriverSpec::Path {
+            path,
+            uri,
+            db_path,
+            entrypoint,
+        } => {
             let ep: Option<&[u8]> = entrypoint.as_deref().map(|s| s.as_bytes());
             let mut d = match ManagedDriver::load_dynamic_from_filename(path, ep, version) {
                 Ok(d) => d,
@@ -131,7 +173,10 @@ pub fn adbc_database_open<'a>(env: Env<'a>, driver_path_or_opts: Term<'a>) -> Te
                 db_opts.push((OptionDatabase::Uri, OptionValue::String(u)));
             }
             if let Some(p) = db_path {
-                db_opts.push((OptionDatabase::Other("path".to_string()), OptionValue::String(p)));
+                db_opts.push((
+                    OptionDatabase::Other("path".to_string()),
+                    OptionValue::String(p),
+                ));
             }
             let db = if db_opts.is_empty() {
                 match d.new_database() {
@@ -177,10 +222,7 @@ pub fn adbc_database_open<'a>(env: Env<'a>, driver_path_or_opts: Term<'a>) -> Te
 
 /// Open a connection from a database. Returns {:ok, connection_ref} or {:error, msg}.
 #[rustler::nif(schedule = "DirtyIo")]
-pub fn adbc_connection_open<'a>(
-    env: Env<'a>,
-    database: ResourceArc<AdbcDatabase>,
-) -> Term<'a> {
+pub fn adbc_connection_open<'a>(env: Env<'a>, database: ResourceArc<AdbcDatabase>) -> Term<'a> {
     let conn = match database.database.new_connection() {
         Ok(c) => c,
         Err(e) => return err_encode(env, &e.to_string()),
@@ -193,10 +235,7 @@ pub fn adbc_connection_open<'a>(
 
 /// Create a new statement from a connection. Returns {:ok, statement_ref} or {:error, msg}.
 #[rustler::nif(schedule = "DirtyIo")]
-pub fn adbc_statement_new<'a>(
-    env: Env<'a>,
-    connection: ResourceArc<AdbcConnection>,
-) -> Term<'a> {
+pub fn adbc_statement_new<'a>(env: Env<'a>, connection: ResourceArc<AdbcConnection>) -> Term<'a> {
     let mut guard = match connection.connection.lock() {
         Ok(g) => g,
         Err(_) => return err_encode(env, "connection lock"),
@@ -223,17 +262,16 @@ pub fn adbc_statement_set_sql<'a>(
         Err(_) => return err_encode(env, "statement lock"),
     };
     match guard.set_sql_query(sql.as_str()) {
-        Ok(()) => rustler::types::atom::Atom::from_str(env, "ok").unwrap().encode(env),
+        Ok(()) => rustler::types::atom::Atom::from_str(env, "ok")
+            .unwrap()
+            .encode(env),
         Err(e) => err_encode(env, &e.to_string()),
     }
 }
 
 /// Execute the statement and return a stream of record batches. Returns {:ok, stream_ref} or {:error, msg}.
 #[rustler::nif(schedule = "DirtyIo")]
-pub fn adbc_statement_execute<'a>(
-    env: Env<'a>,
-    statement: ResourceArc<AdbcStatement>,
-) -> Term<'a> {
+pub fn adbc_statement_execute<'a>(env: Env<'a>, statement: ResourceArc<AdbcStatement>) -> Term<'a> {
     let mut guard = match statement.statement.lock() {
         Ok(g) => g,
         Err(_) => return err_encode(env, "statement lock"),
@@ -278,7 +316,9 @@ pub fn adbc_stream_next<'a>(env: Env<'a>, stream: ResourceArc<AdbcResultStream>)
         Err(_) => return err_encode(env, "stream index lock"),
     };
     if *index_guard >= len {
-        return rustler::types::atom::Atom::from_str(env, "done").unwrap().encode(env);
+        return rustler::types::atom::Atom::from_str(env, "done")
+            .unwrap()
+            .encode(env);
     }
     let i = *index_guard;
     *index_guard += 1;
@@ -309,8 +349,7 @@ pub fn adbc_connection_get_table_types<'a>(
     let out = match guard.get_table_types() {
         Ok(reader) => {
             let schema = reader.schema();
-            let batches: Vec<RecordBatch> = match reader
-                .collect::<std::result::Result<Vec<_>, _>>()
+            let batches: Vec<RecordBatch> = match reader.collect::<std::result::Result<Vec<_>, _>>()
             {
                 Ok(b) => b,
                 Err(e) => return err_encode(env, &e.to_string()),
@@ -419,8 +458,7 @@ pub fn adbc_connection_get_objects<'a>(
     ) {
         Ok(reader) => {
             let schema = reader.schema();
-            let batches: Vec<RecordBatch> = match reader
-                .collect::<std::result::Result<Vec<_>, _>>()
+            let batches: Vec<RecordBatch> = match reader.collect::<std::result::Result<Vec<_>, _>>()
             {
                 Ok(b) => b,
                 Err(e) => return err_encode(env, &e.to_string()),
@@ -454,8 +492,9 @@ pub fn adbc_statement_bind<'a>(
         Err(_) => return err_encode(env, "statement lock"),
     };
     match guard.bind(batch.batch.clone()) {
-        Ok(()) => rustler::types::atom::Atom::from_str(env, "ok").unwrap().encode(env),
+        Ok(()) => rustler::types::atom::Atom::from_str(env, "ok")
+            .unwrap()
+            .encode(env),
         Err(e) => err_encode(env, &e.to_string()),
     }
 }
-

--- a/native/ex_arrow_native/src/cdi.rs
+++ b/native/ex_arrow_native/src/cdi.rs
@@ -189,7 +189,9 @@ pub fn cdi_mark_consumed<'a>(env: Env<'a>, handle: ResourceArc<ExArrowCdiHandle>
         }
     }
 
-    rustler::types::atom::Atom::from_str(env, "ok").unwrap().encode(env)
+    rustler::types::atom::Atom::from_str(env, "ok")
+        .unwrap()
+        .encode(env)
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────

--- a/native/ex_arrow_native/src/compute.rs
+++ b/native/ex_arrow_native/src/compute.rs
@@ -32,7 +32,10 @@ pub fn compute_filter<'a>(
         return err_encode(env, "predicate first column must be boolean");
     };
     match filter_record_batch(&batch.batch, bool_array) {
-        Ok(filtered) => ok_encode(env, ResourceArc::new(ExArrowRecordBatch { batch: filtered })),
+        Ok(filtered) => ok_encode(
+            env,
+            ResourceArc::new(ExArrowRecordBatch { batch: filtered }),
+        ),
         Err(e) => err_encode(env, &e.to_string()),
     }
 }
@@ -60,7 +63,10 @@ pub fn compute_project<'a>(
         Err(e) => return err_encode(env, e.as_str()),
     };
     match batch.batch.project(&indices) {
-        Ok(projected) => ok_encode(env, ResourceArc::new(ExArrowRecordBatch { batch: projected })),
+        Ok(projected) => ok_encode(
+            env,
+            ResourceArc::new(ExArrowRecordBatch { batch: projected }),
+        ),
         Err(e) => err_encode(env, &e.to_string()),
     }
 }
@@ -82,22 +88,24 @@ pub fn compute_sort<'a>(
         Err(_) => return err_encode(env, &format!("column '{}' not found", column_name)),
     };
     let column: &Arc<dyn Array> = batch.batch.column(col_idx);
-    let sort_opts = SortOptions { descending: !ascending, nulls_first: true };
+    let sort_opts = SortOptions {
+        descending: !ascending,
+        nulls_first: true,
+    };
     let indices = match sort_to_indices(column.as_ref(), Some(sort_opts), None) {
         Ok(i) => i,
         Err(e) => return err_encode(env, &e.to_string()),
     };
-    let new_columns: Vec<ArrayRef> =
-        match batch
-            .batch
-            .columns()
-            .iter()
-            .map(|col| take(col.as_ref(), &indices, None).map_err(|e| e.to_string()))
-            .collect::<Result<Vec<_>, _>>()
-        {
-            Ok(cols) => cols,
-            Err(e) => return err_encode(env, e.as_str()),
-        };
+    let new_columns: Vec<ArrayRef> = match batch
+        .batch
+        .columns()
+        .iter()
+        .map(|col| take(col.as_ref(), &indices, None).map_err(|e| e.to_string()))
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(cols) => cols,
+        Err(e) => return err_encode(env, e.as_str()),
+    };
     match RecordBatch::try_new(batch.batch.schema(), new_columns) {
         Ok(sorted) => ok_encode(env, ResourceArc::new(ExArrowRecordBatch { batch: sorted })),
         Err(e) => err_encode(env, &e.to_string()),

--- a/native/ex_arrow_native/src/flight.rs
+++ b/native/ex_arrow_native/src/flight.rs
@@ -4,7 +4,6 @@ use std::io::Cursor;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use arrow::record_batch::RecordBatch;
-use arrow_schema::SchemaRef;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
@@ -15,18 +14,19 @@ use arrow_flight::{
 use arrow_flight::{IpcMessage, SchemaAsIpc};
 use arrow_ipc::reader::StreamReader;
 use arrow_ipc::writer::{IpcWriteOptions, StreamWriter};
+use arrow_schema::SchemaRef;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use rustler::ResourceArc;
 use rustler::{Encoder, Env, Term};
+use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity, Server, ServerTlsConfig};
 use tonic::{Request, Response, Status, Streaming};
-use tokio_stream::wrappers::TcpListenerStream;
 
-use crate::util::{err_encode, ok_encode};
 use crate::resources::{ExArrowIpcStream, ExArrowRecordBatch, ExArrowSchema, IpcStreamBacking};
+use crate::util::{err_encode, ok_encode};
 
 // Pre-registered atoms used when encoding/decoding descriptor tuples and TLS mode.
 rustler::atoms! {
@@ -88,7 +88,10 @@ fn parse_tls_mode<'a>(term: Term<'a>) -> Result<TlsMode, String> {
         }
     }
 
-    Err("invalid tls_mode; expected :plaintext, :system_certs, or {:custom_ca, binary()}".to_string())
+    Err(
+        "invalid tls_mode; expected :plaintext, :system_certs, or {:custom_ca, binary()}"
+            .to_string(),
+    )
 }
 
 /// Encode a `&[u8]` slice as an Elixir **binary** (not a charlist).
@@ -115,7 +118,11 @@ enum ServerTlsMode {
     /// One-way TLS: server presents a certificate; clients verify it.
     Tls { cert_pem: Vec<u8>, key_pem: Vec<u8> },
     /// Mutual TLS: server and client both present certificates.
-    Mtls { cert_pem: Vec<u8>, key_pem: Vec<u8>, ca_pem: Vec<u8> },
+    Mtls {
+        cert_pem: Vec<u8>,
+        key_pem: Vec<u8>,
+        ca_pem: Vec<u8>,
+    },
 }
 
 /// Decode the `server_tls` term sent from Elixir:
@@ -129,17 +136,22 @@ fn parse_server_tls<'a>(term: Term<'a>) -> Result<ServerTlsMode, String> {
         }
         return Err("server_tls atom must be :plaintext".to_string());
     }
-    let tuple = rustler::types::tuple::get_tuple(term)
-        .map_err(|_| "server_tls must be :plaintext, {:tls, cert, key}, or {:mtls, cert, key, ca}".to_string())?;
+    let tuple = rustler::types::tuple::get_tuple(term).map_err(|_| {
+        "server_tls must be :plaintext, {:tls, cert, key}, or {:mtls, cert, key, ca}".to_string()
+    })?;
 
     if tuple.len() == 3 {
         if let Ok(tag) = tuple[0].decode::<rustler::Atom>() {
             if tag == tls() {
-                let cert: rustler::Binary = tuple[1].decode().map_err(|_| "tls cert must be a binary".to_string())?;
-                let key: rustler::Binary  = tuple[2].decode().map_err(|_| "tls key must be a binary".to_string())?;
+                let cert: rustler::Binary = tuple[1]
+                    .decode()
+                    .map_err(|_| "tls cert must be a binary".to_string())?;
+                let key: rustler::Binary = tuple[2]
+                    .decode()
+                    .map_err(|_| "tls key must be a binary".to_string())?;
                 return Ok(ServerTlsMode::Tls {
                     cert_pem: cert.as_slice().to_vec(),
-                    key_pem:  key.as_slice().to_vec(),
+                    key_pem: key.as_slice().to_vec(),
                 });
             }
         }
@@ -147,18 +159,27 @@ fn parse_server_tls<'a>(term: Term<'a>) -> Result<ServerTlsMode, String> {
     if tuple.len() == 4 {
         if let Ok(tag) = tuple[0].decode::<rustler::Atom>() {
             if tag == mtls() {
-                let cert: rustler::Binary = tuple[1].decode().map_err(|_| "mtls cert must be a binary".to_string())?;
-                let key: rustler::Binary  = tuple[2].decode().map_err(|_| "mtls key must be a binary".to_string())?;
-                let ca: rustler::Binary   = tuple[3].decode().map_err(|_| "mtls ca must be a binary".to_string())?;
+                let cert: rustler::Binary = tuple[1]
+                    .decode()
+                    .map_err(|_| "mtls cert must be a binary".to_string())?;
+                let key: rustler::Binary = tuple[2]
+                    .decode()
+                    .map_err(|_| "mtls key must be a binary".to_string())?;
+                let ca: rustler::Binary = tuple[3]
+                    .decode()
+                    .map_err(|_| "mtls ca must be a binary".to_string())?;
                 return Ok(ServerTlsMode::Mtls {
                     cert_pem: cert.as_slice().to_vec(),
-                    key_pem:  key.as_slice().to_vec(),
-                    ca_pem:   ca.as_slice().to_vec(),
+                    key_pem: key.as_slice().to_vec(),
+                    ca_pem: ca.as_slice().to_vec(),
                 });
             }
         }
     }
-    Err("invalid server_tls; expected :plaintext, {:tls, cert, key}, or {:mtls, cert, key, ca}".to_string())
+    Err(
+        "invalid server_tls; expected :plaintext, {:tls, cert, key}, or {:mtls, cert, key, ca}"
+            .to_string(),
+    )
 }
 
 const ECHO_TICKET: &[u8] = b"echo";
@@ -181,8 +202,9 @@ fn schema_ipc_bytes(schema: &SchemaRef) -> Result<Bytes, Status> {
 /// Decode an Elixir descriptor term (`{:cmd, binary()}` or `{:path, [String.t()]}`)
 /// into a `FlightDescriptor`.
 fn decode_descriptor<'a>(term: Term<'a>) -> Result<FlightDescriptor, String> {
-    let tuple = rustler::types::tuple::get_tuple(term)
-        .map_err(|_| "descriptor must be a 2-tuple {:cmd, binary()} or {:path, [string]}".to_string())?;
+    let tuple = rustler::types::tuple::get_tuple(term).map_err(|_| {
+        "descriptor must be a 2-tuple {:cmd, binary()} or {:path, [string]}".to_string()
+    })?;
 
     if tuple.len() != 2 {
         return Err("descriptor tuple must have exactly 2 elements".to_string());
@@ -240,9 +262,7 @@ fn encode_descriptor<'a>(env: Env<'a>, desc: Option<&FlightDescriptor>) -> Optio
                 &[cmd().encode(env), cmd_term],
             ))
         }
-        Some(d) if d.r#type == DESCRIPTOR_PATH => {
-            Some((path(), d.path.clone()).encode(env))
-        }
+        Some(d) if d.r#type == DESCRIPTOR_PATH => Some((path(), d.path.clone()).encode(env)),
         Some(_) => {
             // Unknown/unsupported descriptor type returned by a non-echo server.
             // Emit :nil rather than silently mis-encoding the value as a PATH.
@@ -359,7 +379,9 @@ impl FlightService for EchoFlightService {
                         ..Default::default()
                     }),
                     endpoint: vec![FlightEndpoint {
-                        ticket: Some(Ticket { ticket: ticket_bytes }),
+                        ticket: Some(Ticket {
+                            ticket: ticket_bytes,
+                        }),
                         ..Default::default()
                     }],
                     total_records: total_rows,
@@ -390,7 +412,9 @@ impl FlightService for EchoFlightService {
                     schema: schema_bytes,
                     flight_descriptor: Some(desc),
                     endpoint: vec![FlightEndpoint {
-                        ticket: Some(Ticket { ticket: ticket_bytes }),
+                        ticket: Some(Ticket {
+                            ticket: ticket_bytes,
+                        }),
                         ..Default::default()
                     }],
                     total_records: total_rows,
@@ -418,7 +442,10 @@ impl FlightService for EchoFlightService {
         }
     }
 
-    async fn do_get(&self, request: Request<Ticket>) -> Result<Response<Self::DoGetStream>, Status> {
+    async fn do_get(
+        &self,
+        request: Request<Ticket>,
+    ) -> Result<Response<Self::DoGetStream>, Status> {
         let ticket_key = String::from_utf8_lossy(request.into_inner().ticket.as_ref()).into_owned();
         let (schema, batches) = {
             let guard = self.state.lock().map_err(|_| Status::internal("lock"))?;
@@ -467,17 +494,16 @@ impl FlightService for EchoFlightService {
             .try_collect()
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
-        let schema = batches
-            .first()
-            .map(|b| b.schema())
-            .ok_or_else(|| Status::invalid_argument(
-                "do_put rejected: stream contained no record batches",
-            ))?;
+        let schema = batches.first().map(|b| b.schema()).ok_or_else(|| {
+            Status::invalid_argument("do_put rejected: stream contained no record batches")
+        })?;
         {
             let mut guard = self.state.lock().map_err(|_| Status::internal("lock"))?;
             guard.datasets.insert(ticket_key, (schema, batches));
         }
-        Ok(Response::new(Box::pin(futures::stream::iter([Ok(PutResult::default())]))))
+        Ok(Response::new(Box::pin(futures::stream::iter([Ok(
+            PutResult::default(),
+        )]))))
     }
 
     async fn do_action(
@@ -487,7 +513,9 @@ impl FlightService for EchoFlightService {
         let action = request.into_inner();
         match action.r#type.as_str() {
             "ping" => {
-                let result = arrow_flight::Result { body: Bytes::from("pong") };
+                let result = arrow_flight::Result {
+                    body: Bytes::from("pong"),
+                };
                 Ok(Response::new(Box::pin(futures::stream::iter([Ok(result)]))))
             }
             "clear" => {
@@ -501,7 +529,11 @@ impl FlightService for EchoFlightService {
                 let results: Vec<Result<arrow_flight::Result, Status>> = guard
                     .datasets
                     .keys()
-                    .map(|k| Ok(arrow_flight::Result { body: Bytes::from(k.as_bytes().to_vec()) }))
+                    .map(|k| {
+                        Ok(arrow_flight::Result {
+                            body: Bytes::from(k.as_bytes().to_vec()),
+                        })
+                    })
                     .collect();
                 Ok(Response::new(Box::pin(futures::stream::iter(results))))
             }
@@ -520,11 +552,13 @@ impl FlightService for EchoFlightService {
             }),
             Ok(ArrowActionType {
                 r#type: "ping".to_string(),
-                description: "Responds with 'pong'. Used to verify the server is alive.".to_string(),
+                description: "Responds with 'pong'. Used to verify the server is alive."
+                    .to_string(),
             }),
             Ok(ArrowActionType {
                 r#type: "list_tickets".to_string(),
-                description: "Return one result per stored dataset, each body is the ticket bytes.".to_string(),
+                description: "Return one result per stored dataset, each body is the ticket bytes."
+                    .to_string(),
             }),
         ];
         Ok(Response::new(Box::pin(futures::stream::iter(actions))))
@@ -574,7 +608,12 @@ impl rustler::Resource for FlightServerHandle {}
 /// isolates servers from each other.  Keep the number of simultaneously
 /// live handles small (single digits) to avoid thread exhaustion.
 #[rustler::nif(schedule = "DirtyIo")]
-pub fn flight_server_start<'a>(env: Env<'a>, host: String, port: u16, server_tls: Term<'a>) -> Term<'a> {
+pub fn flight_server_start<'a>(
+    env: Env<'a>,
+    host: String,
+    port: u16,
+    server_tls: Term<'a>,
+) -> Term<'a> {
     let tls_mode = match parse_server_tls(server_tls) {
         Ok(m) => m,
         Err(e) => return err_encode(env, e.as_str()),
@@ -583,21 +622,32 @@ pub fn flight_server_start<'a>(env: Env<'a>, host: String, port: u16, server_tls
         datasets: std::collections::HashMap::new(),
     }));
     let service = EchoFlightService { state };
-    let (tx, rx) = std::sync::mpsc::channel::<Result<(String, u16, tokio::sync::oneshot::Sender<()>), String>>();
+    let (tx, rx) = std::sync::mpsc::channel::<
+        Result<(String, u16, tokio::sync::oneshot::Sender<()>), String>,
+    >();
     let join = std::thread::spawn(move || {
         let rt = match tokio::runtime::Runtime::new() {
             Ok(r) => r,
-            Err(e) => { let _ = tx.send(Err(e.to_string())); return; }
+            Err(e) => {
+                let _ = tx.send(Err(e.to_string()));
+                return;
+            }
         };
         rt.block_on(async move {
             let addr_str = format!("{}:{}", host, port);
             let addr: std::net::SocketAddr = match addr_str.parse() {
                 Ok(a) => a,
-                Err(e) => { let _ = tx.send(Err(e.to_string())); return; }
+                Err(e) => {
+                    let _ = tx.send(Err(e.to_string()));
+                    return;
+                }
             };
             let listener = match tokio::net::TcpListener::bind(addr).await {
                 Ok(l) => l,
-                Err(e) => { let _ = tx.send(Err(e.to_string())); return; }
+                Err(e) => {
+                    let _ = tx.send(Err(e.to_string()));
+                    return;
+                }
             };
             let local = listener.local_addr().unwrap_or_else(|_| addr);
             let actual_port = local.port();
@@ -605,25 +655,32 @@ pub fn flight_server_start<'a>(env: Env<'a>, host: String, port: u16, server_tls
             let incoming = TcpListenerStream::new(listener);
             let svc = FlightServiceServer::new(service);
             let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-            let shutdown_fut = async { let _ = shutdown_rx.await; };
+            let shutdown_fut = async {
+                let _ = shutdown_rx.await;
+            };
 
             // Build the tonic Server, optionally with TLS config.
             let mut builder = Server::builder();
             let server_fut_result = match tls_mode {
-                ServerTlsMode::Plaintext => {
-                    Ok(builder
-                        .add_service(svc)
-                        .serve_with_incoming_shutdown(incoming, shutdown_fut))
-                }
+                ServerTlsMode::Plaintext => Ok(builder
+                    .add_service(svc)
+                    .serve_with_incoming_shutdown(incoming, shutdown_fut)),
                 ServerTlsMode::Tls { cert_pem, key_pem } => {
                     let identity = Identity::from_pem(&cert_pem, &key_pem);
                     let tls_cfg = ServerTlsConfig::new().identity(identity);
                     builder
                         .tls_config(tls_cfg)
-                        .map(|mut b| b.add_service(svc).serve_with_incoming_shutdown(incoming, shutdown_fut))
+                        .map(|mut b| {
+                            b.add_service(svc)
+                                .serve_with_incoming_shutdown(incoming, shutdown_fut)
+                        })
                         .map_err(|e| e.to_string())
                 }
-                ServerTlsMode::Mtls { cert_pem, key_pem, ca_pem } => {
+                ServerTlsMode::Mtls {
+                    cert_pem,
+                    key_pem,
+                    ca_pem,
+                } => {
                     let identity = Identity::from_pem(&cert_pem, &key_pem);
                     let ca_cert = Certificate::from_pem(&ca_pem);
                     let tls_cfg = ServerTlsConfig::new()
@@ -631,13 +688,19 @@ pub fn flight_server_start<'a>(env: Env<'a>, host: String, port: u16, server_tls
                         .client_ca_root(ca_cert);
                     builder
                         .tls_config(tls_cfg)
-                        .map(|mut b| b.add_service(svc).serve_with_incoming_shutdown(incoming, shutdown_fut))
+                        .map(|mut b| {
+                            b.add_service(svc)
+                                .serve_with_incoming_shutdown(incoming, shutdown_fut)
+                        })
                         .map_err(|e| e.to_string())
                 }
             };
             let server_fut = match server_fut_result {
                 Ok(f) => f,
-                Err(e) => { let _ = tx.send(Err(e)); return; }
+                Err(e) => {
+                    let _ = tx.send(Err(e));
+                    return;
+                }
             };
             let server_handle = tokio::spawn(server_fut);
             let probe_ip = if actual_host == "0.0.0.0" || actual_host == "::" {
@@ -656,7 +719,8 @@ pub fn flight_server_start<'a>(env: Env<'a>, host: String, port: u16, server_tls
             }
             if !ready {
                 let _ = tx.send(Err(format!(
-                    "server on {}:{} did not become ready within 2s", actual_host, actual_port
+                    "server on {}:{} did not become ready within 2s",
+                    actual_host, actual_port
                 )));
                 return;
             }
@@ -704,7 +768,9 @@ pub fn flight_server_stop<'a>(env: Env<'a>, handle: ResourceArc<FlightServerHand
             let _ = join.join();
         }
     }
-    rustler::types::atom::Atom::from_str(env, "ok").unwrap().encode(env)
+    rustler::types::atom::Atom::from_str(env, "ok")
+        .unwrap()
+        .encode(env)
 }
 
 // ── Shared client Tokio runtime ───────────────────────────────────────────────
@@ -859,7 +925,9 @@ pub fn flight_client_do_put<'a>(
     match client.rt.block_on(guard.do_put(flight_data)) {
         Ok(mut result_stream) => {
             while client.rt.block_on(result_stream.next()).is_some() {}
-            rustler::types::atom::Atom::from_str(env, "ok").unwrap().encode(env)
+            rustler::types::atom::Atom::from_str(env, "ok")
+                .unwrap()
+                .encode(env)
         }
         Err(e) => err_encode(env, &e.to_string()),
     }
@@ -983,10 +1051,7 @@ pub fn flight_client_list_flights<'a>(
             }
         }
     };
-    let terms: Option<Vec<Term<'a>>> = flights
-        .iter()
-        .map(|f| encode_flight_info(env, f))
-        .collect();
+    let terms: Option<Vec<Term<'a>>> = flights.iter().map(|f| encode_flight_info(env, f)).collect();
     match terms {
         Some(t) => ok_encode(env, t),
         None => err_encode(env, "binary allocation failed while encoding FlightInfo"),
@@ -1069,7 +1134,12 @@ pub fn flight_client_get_schema<'a>(
             }
         }
     };
-    ok_encode(env, ResourceArc::new(ExArrowSchema { schema: schema_ref.into() }))
+    ok_encode(
+        env,
+        ResourceArc::new(ExArrowSchema {
+            schema: schema_ref.into(),
+        }),
+    )
 }
 
 /// list_actions: enumerate the action types supported by the server.
@@ -1165,10 +1235,13 @@ pub fn flight_client_do_action<'a>(
             }
         }
     };
-    let body_terms: Option<Vec<Term<'a>>> = results.iter().map(|r| try_encode_binary(env, r)).collect();
+    let body_terms: Option<Vec<Term<'a>>> =
+        results.iter().map(|r| try_encode_binary(env, r)).collect();
     match body_terms {
         Some(t) => ok_encode(env, t),
-        None => err_encode(env, "binary allocation failed while encoding action results"),
+        None => err_encode(
+            env,
+            "binary allocation failed while encoding action results",
+        ),
     }
 }
-

--- a/native/ex_arrow_native/src/flight_sql.rs
+++ b/native/ex_arrow_native/src/flight_sql.rs
@@ -87,7 +87,7 @@ impl rustler::Resource for FlightSqlStreamResource {}
 pub struct FlightSqlPreparedStatementResource {
     pub rt: Arc<tokio::runtime::Runtime>,
     pub client: Arc<Mutex<FlightSqlServiceClient<Channel>>>,
-    pub stmt: Mutex<PreparedStatement<Channel>>,
+    pub stmt: Mutex<Option<PreparedStatement<Channel>>>,
 }
 
 #[rustler::resource_impl]
@@ -711,14 +711,15 @@ pub fn flight_sql_get_sql_info<'a>(
 /// Prepare a SQL query on the server and return an opaque statement handle.
 ///
 /// The server parses and plans the query, returning a
-/// `FlightSqlPreparedStatementResource` that can be executed one or more
-/// times via `flight_sql_prepared_execute` or
-/// `flight_sql_prepared_execute_update`.
+/// `FlightSqlPreparedStatementResource` that can be bound, executed, and
+/// closed.
+///
+/// After preparing, parameters can be bound with `flight_sql_prepared_bind`,
+/// the statement can be executed with `flight_sql_prepared_execute` or
+/// `flight_sql_prepared_execute_update`, and the handle should be closed
+/// with `flight_sql_prepared_close` to release server-side resources.
 ///
 /// Returns `{:ok, stmt_ref}` or `{:error, {code, grpc_status, message}}`.
-///
-/// Parameter binding is not supported in v0.5.0 — the statement executes
-/// with no bound parameters.
 #[rustler::nif(schedule = "DirtyIo")]
 pub fn flight_sql_prepare<'a>(
     env: Env<'a>,
@@ -741,7 +742,7 @@ pub fn flight_sql_prepare<'a>(
     let resource = FlightSqlPreparedStatementResource {
         rt,
         client: client_ref.client.clone(),
-        stmt: Mutex::new(stmt),
+        stmt: Mutex::new(Some(stmt)),
     };
     ok_encode(env, ResourceArc::new(resource))
 }
@@ -764,7 +765,11 @@ pub fn flight_sql_prepared_execute<'a>(
             Ok(g) => g,
             Err(_) => return err_encode(env, "statement lock poisoned"),
         };
-        match rt.block_on(guard.execute()) {
+        let stmt = match guard.as_mut() {
+            Some(s) => s,
+            None => return encode_sql_error(env, protocol_error(), 0, "statement is closed"),
+        };
+        match rt.block_on(stmt.execute()) {
             Ok(info) => info,
             Err(e) => return arrow_error_to_term(env, &e),
         }
@@ -788,10 +793,120 @@ pub fn flight_sql_prepared_execute_update<'a>(
         Ok(g) => g,
         Err(_) => return err_encode(env, "statement lock poisoned"),
     };
+    let stmt = match guard.as_mut() {
+        Some(s) => s,
+        None => return encode_sql_error(env, protocol_error(), 0, "statement is closed"),
+    };
 
-    match rt.block_on(guard.execute_update()) {
+    match rt.block_on(stmt.execute_update()) {
         Ok(n) if n < 0 => (ok(), unknown()).encode(env),
         Ok(n) => (ok(), n as u64).encode(env),
+        Err(e) => arrow_error_to_term(env, &e),
+    }
+}
+
+/// Bind a RecordBatch of parameters to a prepared statement.
+///
+/// The RecordBatch must match the parameter schema returned by the server
+/// during `CreatePreparedStatement`.  Column names must match parameter
+/// names; column types must be compatible.
+///
+/// The arrow-flight crate's `PreparedStatement::set_parameters` stores the
+/// batch internally; `write_bind_params` sends it to the server during the
+/// next `execute` or `execute_update` call.
+///
+/// Returns `:ok` on success, `{:error, {code, grpc_status, message}}` on failure.
+#[rustler::nif(schedule = "DirtyIo")]
+pub fn flight_sql_prepared_bind<'a>(
+    env: Env<'a>,
+    stmt_ref: ResourceArc<FlightSqlPreparedStatementResource>,
+    batch_ref: ResourceArc<ExArrowRecordBatch>,
+) -> Term<'a> {
+    let mut guard = match stmt_ref.stmt.lock() {
+        Ok(g) => g,
+        Err(_) => return err_encode(env, "statement lock poisoned"),
+    };
+
+    let stmt = match guard.as_mut() {
+        Some(s) => s,
+        None => return encode_sql_error(env, protocol_error(), 0, "statement is closed"),
+    };
+
+    match stmt.set_parameters(batch_ref.batch.clone()) {
+        Ok(()) => ok_encode(env, rustler::types::atom::ok()),
+        Err(e) => arrow_error_to_term(env, &e),
+    }
+}
+
+/// Return the parameter schema of a prepared statement.
+///
+/// The schema describes the expected column names and Arrow types for
+/// parameter binding.  An empty schema means the statement takes no
+/// parameters.
+///
+/// Returns `{:ok, schema_ref}` or `{:error, {code, grpc_status, message}}`.
+#[rustler::nif(schedule = "DirtyIo")]
+pub fn flight_sql_prepared_parameter_schema<'a>(
+    env: Env<'a>,
+    stmt_ref: ResourceArc<FlightSqlPreparedStatementResource>,
+) -> Term<'a> {
+    let guard = match stmt_ref.stmt.lock() {
+        Ok(g) => g,
+        Err(_) => return err_encode(env, "statement lock poisoned"),
+    };
+
+    let stmt = match guard.as_ref() {
+        Some(s) => s,
+        None => return encode_sql_error(env, protocol_error(), 0, "statement is closed"),
+    };
+
+    match stmt.parameter_schema() {
+        Ok(schema) => {
+            let schema_ref = ExArrowSchema {
+                schema: Arc::new(schema.clone()),
+            };
+            ok_encode(env, ResourceArc::new(schema_ref))
+        }
+        Err(e) => arrow_error_to_term(env, &e),
+    }
+}
+
+/// Close a prepared statement and release server-side resources.
+///
+/// Sends `ActionClosePreparedStatement` to the server.  After this call
+/// the statement handle must not be used again — subsequent bind, execute,
+/// or close calls will return `{:error, {:protocol_error, 0, "statement is closed"}}`.
+///
+/// Close is idempotent — calling it on an already-closed statement returns `:ok`.
+///
+/// Returns `:ok` on success, `{:error, {code, grpc_status, message}}` on failure.
+#[rustler::nif(schedule = "DirtyIo")]
+pub fn flight_sql_prepared_close<'a>(
+    env: Env<'a>,
+    stmt_ref: ResourceArc<FlightSqlPreparedStatementResource>,
+) -> Term<'a> {
+    let rt = stmt_ref.rt.clone();
+
+    // Take ownership of the PreparedStatement out of the Option.
+    // This prevents any further use of the statement through this handle.
+    let stmt = {
+        let mut guard = match stmt_ref.stmt.lock() {
+            Ok(g) => g,
+            Err(_) => return err_encode(env, "statement lock poisoned"),
+        };
+        match guard.take() {
+            Some(s) => s,
+            None => {
+                // Already closed — idempotent close returns :ok
+                return ok_encode(env, rustler::types::atom::ok());
+            }
+        }
+    };
+
+    // PreparedStatement::close(self) consumes self and sends
+    // ActionClosePreparedStatement to the server.
+    match rt.block_on(stmt.close()) {
+        Ok(()) => ok_encode(env, rustler::types::atom::ok()),
         Err(e) => arrow_error_to_term(env, &e),
     }
 }

--- a/native/ex_arrow_native/src/flight_sql.rs
+++ b/native/ex_arrow_native/src/flight_sql.rs
@@ -20,7 +20,7 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig};
 use crate::resources::{ExArrowRecordBatch, ExArrowSchema};
 use crate::util::{err_encode, ok_encode};
 
-// ── Atoms ─────────────────────────────────────────────────────────────────────
+// Atoms
 
 // All atoms used in this module declared in a single block to avoid conflicts.
 rustler::atoms! {
@@ -39,13 +39,13 @@ rustler::atoms! {
     multi_endpoint,
     unknown,
     done,
-    // TLS mode atoms (same values as flight.rs — atoms are global BEAM atoms)
+    // TLS mode atoms (same values as flight.rs; atoms are global BEAM atoms)
     plaintext,
     system_certs,
     custom_ca,
 }
 
-// ── Resource types ────────────────────────────────────────────────────────────
+// Resource types
 
 /// Opaque handle for an active Flight SQL connection.
 ///
@@ -65,7 +65,7 @@ impl rustler::Resource for FlightSqlClientHandle {}
 /// The stream is pinned on the heap so it can be driven from multiple
 /// NIF calls without requiring a stable stack address.
 ///
-/// `rt` is the Tokio runtime that owns the gRPC channel — stored here so
+/// `rt` is the Tokio runtime that owns the gRPC channel; stored here so
 /// `flight_sql_stream_next` uses the same runtime as the one that opened the
 /// connection, keeping stream I/O isolated from any other runtime.
 pub struct FlightSqlStreamResource {
@@ -93,7 +93,7 @@ pub struct FlightSqlPreparedStatementResource {
 #[rustler::resource_impl]
 impl rustler::Resource for FlightSqlPreparedStatementResource {}
 
-// ── Tokio runtime ─────────────────────────────────────────────────────────────
+// Tokio runtime
 
 /// Shared Tokio runtime for all Flight SQL async operations.
 ///
@@ -115,7 +115,7 @@ fn sql_runtime() -> Arc<tokio::runtime::Runtime> {
         .clone()
 }
 
-// ── TLS mode ──────────────────────────────────────────────────────────────────
+// TLS mode
 
 enum TlsMode {
     Plaintext,
@@ -131,9 +131,7 @@ fn parse_tls_mode<'a>(term: Term<'a>) -> Result<TlsMode, String> {
         if atom == system_certs() {
             return Ok(TlsMode::SystemCerts);
         }
-        return Err(
-            "unknown tls_mode atom; expected :plaintext or :system_certs".to_string(),
-        );
+        return Err("unknown tls_mode atom; expected :plaintext or :system_certs".to_string());
     }
 
     let tuple = rustler::types::tuple::get_tuple(term).map_err(|_| {
@@ -157,7 +155,7 @@ fn parse_tls_mode<'a>(term: Term<'a>) -> Result<TlsMode, String> {
     )
 }
 
-// ── Error encoding ────────────────────────────────────────────────────────────
+// Error encoding
 
 /// Encode a Flight SQL error as `{:error, {code_atom, grpc_status_integer, message}}`.
 ///
@@ -178,12 +176,8 @@ fn flight_error_to_term<'a>(env: Env<'a>, err: FlightError) -> Term<'a> {
             encode_sql_error(env, code, grpc_code, status.message())
         }
         FlightError::Arrow(inner) => arrow_error_to_term(env, inner),
-        FlightError::DecodeError(msg) => {
-            encode_sql_error(env, protocol_error(), 0, msg)
-        }
-        FlightError::ProtocolError(msg) => {
-            encode_sql_error(env, protocol_error(), 0, msg)
-        }
+        FlightError::DecodeError(msg) => encode_sql_error(env, protocol_error(), 0, msg),
+        FlightError::ProtocolError(msg) => encode_sql_error(env, protocol_error(), 0, msg),
         other => encode_sql_error(env, transport_error(), 0, &other.to_string()),
     }
 }
@@ -312,11 +306,11 @@ fn extract_quoted_field(s: &str, prefix: &str) -> Option<String> {
     Some(result)
 }
 
-// ── Schema decode helper ──────────────────────────────────────────────────────
+// Schema decode helper
 
 /// Decode the IPC-encoded schema bytes from a `FlightInfo` response.
 ///
-/// Returns an empty schema when `bytes` is empty — some servers omit the
+/// Returns an empty schema when `bytes` is empty; some servers omit the
 /// schema in `FlightInfo` and send it as the first `FlightData` message
 /// instead.  The `FlightRecordBatchStream` decoder handles that path
 /// transparently.
@@ -329,7 +323,7 @@ fn decode_flight_schema(bytes: bytes::Bytes) -> Result<SchemaRef, String> {
         .map_err(|e| format!("schema decode: {e}"))
 }
 
-// ── NIFs ──────────────────────────────────────────────────────────────────────
+// NIFs
 
 /// Connect to a Flight SQL server.
 ///
@@ -398,7 +392,7 @@ pub fn flight_sql_connect<'a>(
 /// Returns `{:ok, stream_ref}` or `{:error, {code, grpc_status, message}}`.
 ///
 /// Returns `{:error, {multi_endpoint, 0, message}}` when `FlightInfo` contains
-/// more than one endpoint — multi-endpoint distribution is not supported in v0.5.0.
+/// more than one endpoint; multi-endpoint distribution is not supported in v0.5.0.
 ///
 /// **Concurrency note**: concurrent calls on the same client handle are serialised
 /// by an internal Mutex.  `FlightSqlServiceClient::execute` requires exclusive
@@ -439,14 +433,7 @@ pub fn flight_sql_query<'a>(
     // Step 3: Extract ticket
     let ticket = match flight_info.endpoint[0].ticket.clone() {
         Some(t) => t,
-        None => {
-            return encode_sql_error(
-                env,
-                protocol_error(),
-                0,
-                "FlightEndpoint has no ticket",
-            )
-        }
+        None => return encode_sql_error(env, protocol_error(), 0, "FlightEndpoint has no ticket"),
     };
 
     // Step 4: Decode schema from FlightInfo schema bytes
@@ -460,7 +447,7 @@ pub fn flight_sql_query<'a>(
         Ok(s) => s,
         Err(e) => return arrow_error_to_term(env, &e),
     };
-    // Release the lock — the stream owns its own connection internally.
+    // Release the lock; the stream owns its own connection internally.
     drop(guard);
 
     let resource = FlightSqlStreamResource {
@@ -515,9 +502,9 @@ pub fn flight_sql_stream_schema<'a>(
 /// Read the next record batch from a Flight SQL stream.
 ///
 /// Returns:
-/// - `{:ok, batch_ref}` — the next batch (data stays in native memory).
-/// - `:done` — the stream is exhausted.
-/// - `{:error, {code, grpc_status, message}}` — a transport or server error.
+/// - `{:ok, batch_ref}`: the next batch (data stays in native memory).
+/// - `:done`: the stream is exhausted.
+/// - `{:error, {code, grpc_status, message}}`: transport or server error.
 #[rustler::nif(schedule = "DirtyIo")]
 pub fn flight_sql_stream_next<'a>(
     env: Env<'a>,
@@ -539,7 +526,7 @@ pub fn flight_sql_stream_next<'a>(
     }
 }
 
-// ── Metadata helpers ──────────────────────────────────────────────────────────
+// Metadata helpers
 
 /// Shared post-processing for any `FlightInfo`-returning metadata call.
 ///
@@ -566,14 +553,7 @@ fn flight_info_to_stream<'a>(
 
     let ticket = match flight_info.endpoint[0].ticket.clone() {
         Some(t) => t,
-        None => {
-            return encode_sql_error(
-                env,
-                protocol_error(),
-                0,
-                "FlightEndpoint has no ticket",
-            )
-        }
+        None => return encode_sql_error(env, protocol_error(), 0, "FlightEndpoint has no ticket"),
     };
 
     let schema = match decode_flight_schema(flight_info.schema) {
@@ -600,7 +580,7 @@ fn flight_info_to_stream<'a>(
     ok_encode(env, ResourceArc::new(resource))
 }
 
-// ── Metadata NIFs ─────────────────────────────────────────────────────────────
+// Metadata NIFs
 
 /// List tables visible to the connected user.
 ///
@@ -706,7 +686,7 @@ pub fn flight_sql_get_sql_info<'a>(
     flight_info_to_stream(env, &rt, &client_ref.client, flight_info)
 }
 
-// ── Prepared statement NIFs ───────────────────────────────────────────────────
+// Prepared statement NIFs
 
 /// Prepare a SQL query on the server and return an opaque statement handle.
 ///
@@ -745,64 +725,6 @@ pub fn flight_sql_prepare<'a>(
         stmt: Mutex::new(Some(stmt)),
     };
     ok_encode(env, ResourceArc::new(resource))
-}
-
-/// Execute a prepared statement and return a lazy record-batch stream.
-///
-/// Performs `ExecutePreparedStatement` followed by `DoGet` on the returned
-/// endpoint.
-///
-/// Returns `{:ok, stream_ref}` or `{:error, {code, grpc_status, message}}`.
-#[rustler::nif(schedule = "DirtyIo")]
-pub fn flight_sql_prepared_execute<'a>(
-    env: Env<'a>,
-    stmt_ref: ResourceArc<FlightSqlPreparedStatementResource>,
-) -> Term<'a> {
-    let rt = stmt_ref.rt.clone();
-
-    let flight_info = {
-        let mut guard = match stmt_ref.stmt.lock() {
-            Ok(g) => g,
-            Err(_) => return err_encode(env, "statement lock poisoned"),
-        };
-        let stmt = match guard.as_mut() {
-            Some(s) => s,
-            None => return encode_sql_error(env, protocol_error(), 0, "statement is closed"),
-        };
-        match rt.block_on(stmt.execute()) {
-            Ok(info) => info,
-            Err(e) => return arrow_error_to_term(env, &e),
-        }
-    };
-
-    flight_info_to_stream(env, &rt, &stmt_ref.client, flight_info)
-}
-
-/// Execute a prepared DML/DDL statement and return the affected row count.
-///
-/// Returns `{:ok, n}` where `n` is the number of affected rows, or
-/// `{:ok, :unknown}` when the server does not report a count.
-/// Returns `{:error, {code, grpc_status, message}}` on failure.
-#[rustler::nif(schedule = "DirtyIo")]
-pub fn flight_sql_prepared_execute_update<'a>(
-    env: Env<'a>,
-    stmt_ref: ResourceArc<FlightSqlPreparedStatementResource>,
-) -> Term<'a> {
-    let rt = stmt_ref.rt.clone();
-    let mut guard = match stmt_ref.stmt.lock() {
-        Ok(g) => g,
-        Err(_) => return err_encode(env, "statement lock poisoned"),
-    };
-    let stmt = match guard.as_mut() {
-        Some(s) => s,
-        None => return encode_sql_error(env, protocol_error(), 0, "statement is closed"),
-    };
-
-    match rt.block_on(stmt.execute_update()) {
-        Ok(n) if n < 0 => (ok(), unknown()).encode(env),
-        Ok(n) => (ok(), n as u64).encode(env),
-        Err(e) => arrow_error_to_term(env, &e),
-    }
 }
 
 /// Bind a RecordBatch of parameters to a prepared statement.
@@ -871,13 +793,71 @@ pub fn flight_sql_prepared_parameter_schema<'a>(
     }
 }
 
+/// Execute a prepared statement and return a lazy record-batch stream.
+///
+/// Performs `ExecutePreparedStatement` followed by `DoGet` on the returned
+/// endpoint.
+///
+/// Returns `{:ok, stream_ref}` or `{:error, {code, grpc_status, message}}`.
+#[rustler::nif(schedule = "DirtyIo")]
+pub fn flight_sql_prepared_execute<'a>(
+    env: Env<'a>,
+    stmt_ref: ResourceArc<FlightSqlPreparedStatementResource>,
+) -> Term<'a> {
+    let rt = stmt_ref.rt.clone();
+
+    let flight_info = {
+        let mut guard = match stmt_ref.stmt.lock() {
+            Ok(g) => g,
+            Err(_) => return err_encode(env, "statement lock poisoned"),
+        };
+        let stmt = match guard.as_mut() {
+            Some(s) => s,
+            None => return encode_sql_error(env, protocol_error(), 0, "statement is closed"),
+        };
+        match rt.block_on(stmt.execute()) {
+            Ok(info) => info,
+            Err(e) => return arrow_error_to_term(env, &e),
+        }
+    };
+
+    flight_info_to_stream(env, &rt, &stmt_ref.client, flight_info)
+}
+
+/// Execute a prepared DML/DDL statement and return the affected row count.
+///
+/// Returns `{:ok, n}` where `n` is the number of affected rows, or
+/// `{:ok, :unknown}` when the server does not report a count.
+/// Returns `{:error, {code, grpc_status, message}}` on failure.
+#[rustler::nif(schedule = "DirtyIo")]
+pub fn flight_sql_prepared_execute_update<'a>(
+    env: Env<'a>,
+    stmt_ref: ResourceArc<FlightSqlPreparedStatementResource>,
+) -> Term<'a> {
+    let rt = stmt_ref.rt.clone();
+    let mut guard = match stmt_ref.stmt.lock() {
+        Ok(g) => g,
+        Err(_) => return err_encode(env, "statement lock poisoned"),
+    };
+    let stmt = match guard.as_mut() {
+        Some(s) => s,
+        None => return encode_sql_error(env, protocol_error(), 0, "statement is closed"),
+    };
+
+    match rt.block_on(stmt.execute_update()) {
+        Ok(n) if n < 0 => (ok(), unknown()).encode(env),
+        Ok(n) => (ok(), n as u64).encode(env),
+        Err(e) => arrow_error_to_term(env, &e),
+    }
+}
+
 /// Close a prepared statement and release server-side resources.
 ///
 /// Sends `ActionClosePreparedStatement` to the server.  After this call
-/// the statement handle must not be used again — subsequent bind, execute,
+/// the statement handle must not be used again; subsequent bind, execute,
 /// or close calls will return `{:error, {:protocol_error, 0, "statement is closed"}}`.
 ///
-/// Close is idempotent — calling it on an already-closed statement returns `:ok`.
+/// Close is idempotent; calling it on an already-closed statement returns `:ok`.
 ///
 /// ## Behaviour on error
 ///
@@ -908,7 +888,7 @@ pub fn flight_sql_prepared_close<'a>(
         match guard.take() {
             Some(s) => s,
             None => {
-                // Already closed — idempotent close returns :ok
+                // Already closed; idempotent close returns :ok
                 return ok_encode(env, rustler::types::atom::ok());
             }
         }

--- a/native/ex_arrow_native/src/flight_sql.rs
+++ b/native/ex_arrow_native/src/flight_sql.rs
@@ -879,6 +879,17 @@ pub fn flight_sql_prepared_parameter_schema<'a>(
 ///
 /// Close is idempotent — calling it on an already-closed statement returns `:ok`.
 ///
+/// ## Behaviour on error
+///
+/// `PreparedStatement::close(self)` consumes the statement, so even when the
+/// underlying gRPC call fails the statement is taken out of the resource's
+/// `Mutex<Option<...>>` and dropped.  This means:
+///
+/// - The Elixir resource is in the closed state regardless of return value.
+/// - A retry call to this NIF returns `:ok` (idempotent path).
+/// - The server-side resource may or may not be freed; transient transport
+///   errors may leave it allocated until the connection is dropped.
+///
 /// Returns `:ok` on success, `{:error, {code, grpc_status, message}}` on failure.
 #[rustler::nif(schedule = "DirtyIo")]
 pub fn flight_sql_prepared_close<'a>(

--- a/native/ex_arrow_native/src/ipc.rs
+++ b/native/ex_arrow_native/src/ipc.rs
@@ -6,13 +6,17 @@ use std::sync::Arc;
 use arrow::array::{BooleanArray, Int64Array, StringArray};
 use arrow::record_batch::RecordBatch;
 use arrow_array::types::{
-    Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
-    UInt64Type, UInt8Type,
+    Date32Type, Date64Type, DurationMicrosecondType, DurationMillisecondType,
+    DurationNanosecondType, DurationSecondType, Float32Type, Float64Type, Int16Type, Int32Type,
+    Int64Type, Int8Type, TimestampMicrosecondType, TimestampMillisecondType,
+    TimestampNanosecondType, TimestampSecondType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
 };
-use arrow_array::{Array, ArrayRef, PrimitiveArray};
+use arrow_array::{
+    Array, ArrayRef, BinaryArray, LargeBinaryArray, LargeStringArray, PrimitiveArray,
+};
 use arrow_buffer::Buffer;
 use arrow_data::ArrayData;
-use arrow_schema::{DataType, Field, Schema};
+use arrow_schema::{DataType, Field, Schema, TimeUnit};
 
 use arrow_ipc::reader::{FileReader, StreamReader};
 use arrow_ipc::writer::{FileWriter, StreamWriter};
@@ -596,9 +600,20 @@ pub fn record_batch_concat<'a>(
 }
 
 // ── Column-array builder (shared by single-column and multi-column NIFs) ─────
+//
+// Wire formats accepted by `build_column_array`:
+//
+// * Fixed-width primitives (s8..s64, u8..u64, f32, f64, date32, date64,
+//   timestamp_*, duration_*) — `length × element_size` bytes, little-endian
+//   for multi-byte types.
+// * `bool` — exactly `length` bytes, one byte per element (0 = false,
+//   non-zero = true).
+// * `utf8`, `large_utf8`, `binary`, `large_binary` — concatenation of N
+//   length-prefixed records, each of the form
+//   `<<elem_len::u32-little, elem_bytes::binary-size(elem_len)>>`.
 
-macro_rules! build_col {
-    ($bytes:expr, $length:expr, $NativeType:ty, $ArrowDType:expr) => {{
+macro_rules! build_fixed_col {
+    ($bytes:expr, $length:expr, $NativeType:ty, $ArrowType:ty, $ArrowDType:expr) => {{
         let elem_size = std::mem::size_of::<$NativeType>();
         if $bytes.len() != $length * elem_size {
             return Err(format!(
@@ -615,25 +630,34 @@ macro_rules! build_col {
             .add_buffer(buf)
             .build()
             .map_err(|e| e.to_string())?;
-        let array: ArrayRef = Arc::new(
-            PrimitiveArray::<<$NativeType as NativeTypeAlias>::ArrowType>::from(array_data),
-        );
+        let array: ArrayRef = Arc::new(PrimitiveArray::<$ArrowType>::from(array_data));
         ($ArrowDType, array)
     }};
 }
 
-fn build_column_array(bytes: &[u8], dtype_str: &str, length: usize) -> Result<(DataType, ArrayRef), String> {
+fn build_column_array(
+    bytes: &[u8],
+    dtype_str: &str,
+    length: usize,
+) -> Result<(DataType, ArrayRef), String> {
     let pair = match dtype_str {
-        "s8"  => build_col!(bytes, length, i8,  DataType::Int8),
-        "s16" => build_col!(bytes, length, i16, DataType::Int16),
-        "s32" => build_col!(bytes, length, i32, DataType::Int32),
-        "s64" => build_col!(bytes, length, i64, DataType::Int64),
-        "u8"  => build_col!(bytes, length, u8,  DataType::UInt8),
-        "u16" => build_col!(bytes, length, u16, DataType::UInt16),
-        "u32" => build_col!(bytes, length, u32, DataType::UInt32),
-        "u64" => build_col!(bytes, length, u64, DataType::UInt64),
-        "f32" => build_col!(bytes, length, f32, DataType::Float32),
-        "f64" => build_col!(bytes, length, f64, DataType::Float64),
+        // ── Signed integers ─────────────────────────────────────────
+        "s8"  => build_fixed_col!(bytes, length, i8,  Int8Type,  DataType::Int8),
+        "s16" => build_fixed_col!(bytes, length, i16, Int16Type, DataType::Int16),
+        "s32" => build_fixed_col!(bytes, length, i32, Int32Type, DataType::Int32),
+        "s64" => build_fixed_col!(bytes, length, i64, Int64Type, DataType::Int64),
+
+        // ── Unsigned integers ───────────────────────────────────────
+        "u8"  => build_fixed_col!(bytes, length, u8,  UInt8Type,  DataType::UInt8),
+        "u16" => build_fixed_col!(bytes, length, u16, UInt16Type, DataType::UInt16),
+        "u32" => build_fixed_col!(bytes, length, u32, UInt32Type, DataType::UInt32),
+        "u64" => build_fixed_col!(bytes, length, u64, UInt64Type, DataType::UInt64),
+
+        // ── Floats ──────────────────────────────────────────────────
+        "f32" => build_fixed_col!(bytes, length, f32, Float32Type, DataType::Float32),
+        "f64" => build_fixed_col!(bytes, length, f64, Float64Type, DataType::Float64),
+
+        // ── Boolean ─────────────────────────────────────────────────
         "bool" => {
             if bytes.len() != length {
                 return Err(format!(
@@ -646,44 +670,140 @@ fn build_column_array(bytes: &[u8], dtype_str: &str, length: usize) -> Result<(D
             let array: ArrayRef = Arc::new(BooleanArray::from(bool_vals));
             (DataType::Boolean, array)
         }
+
+        // ── Date / Time ─────────────────────────────────────────────
+        // date32:        i32 days since 1970-01-01
+        // date64:        i64 milliseconds since 1970-01-01
+        // timestamp_*:   i64 ticks (s/ms/us/ns) since 1970-01-01 UTC
+        // duration_*:    i64 ticks (s/ms/us/ns)
+        "date32" => build_fixed_col!(bytes, length, i32, Date32Type, DataType::Date32),
+        "date64" => build_fixed_col!(bytes, length, i64, Date64Type, DataType::Date64),
+
+        "timestamp_seconds" => build_fixed_col!(
+            bytes, length, i64, TimestampSecondType,
+            DataType::Timestamp(TimeUnit::Second, None)
+        ),
+        "timestamp_millis" => build_fixed_col!(
+            bytes, length, i64, TimestampMillisecondType,
+            DataType::Timestamp(TimeUnit::Millisecond, None)
+        ),
+        "timestamp_micros" => build_fixed_col!(
+            bytes, length, i64, TimestampMicrosecondType,
+            DataType::Timestamp(TimeUnit::Microsecond, None)
+        ),
+        "timestamp_nanos" => build_fixed_col!(
+            bytes, length, i64, TimestampNanosecondType,
+            DataType::Timestamp(TimeUnit::Nanosecond, None)
+        ),
+
+        "duration_seconds" => build_fixed_col!(
+            bytes, length, i64, DurationSecondType,
+            DataType::Duration(TimeUnit::Second)
+        ),
+        "duration_millis" => build_fixed_col!(
+            bytes, length, i64, DurationMillisecondType,
+            DataType::Duration(TimeUnit::Millisecond)
+        ),
+        "duration_micros" => build_fixed_col!(
+            bytes, length, i64, DurationMicrosecondType,
+            DataType::Duration(TimeUnit::Microsecond)
+        ),
+        "duration_nanos" => build_fixed_col!(
+            bytes, length, i64, DurationNanosecondType,
+            DataType::Duration(TimeUnit::Nanosecond)
+        ),
+
+        // ── Variable-length string / binary ─────────────────────────
+        "utf8" => {
+            let elems = decode_varlen_records(bytes, length, "utf8")?;
+            let strs: Vec<&str> = elems
+                .iter()
+                .map(|e| std::str::from_utf8(e).map_err(|err| format!("invalid utf-8: {}", err)))
+                .collect::<Result<_, _>>()?;
+            let array: ArrayRef = Arc::new(StringArray::from(strs));
+            (DataType::Utf8, array)
+        }
+        "large_utf8" => {
+            let elems = decode_varlen_records(bytes, length, "large_utf8")?;
+            let strs: Vec<&str> = elems
+                .iter()
+                .map(|e| std::str::from_utf8(e).map_err(|err| format!("invalid utf-8: {}", err)))
+                .collect::<Result<_, _>>()?;
+            let array: ArrayRef = Arc::new(LargeStringArray::from(strs));
+            (DataType::LargeUtf8, array)
+        }
+        "binary" => {
+            let elems = decode_varlen_records(bytes, length, "binary")?;
+            let array: ArrayRef =
+                Arc::new(BinaryArray::from(elems.iter().map(|e| e.as_ref()).collect::<Vec<&[u8]>>()));
+            (DataType::Binary, array)
+        }
+        "large_binary" => {
+            let elems = decode_varlen_records(bytes, length, "large_binary")?;
+            let array: ArrayRef = Arc::new(LargeBinaryArray::from(
+                elems.iter().map(|e| e.as_ref()).collect::<Vec<&[u8]>>(),
+            ));
+            (DataType::LargeBinary, array)
+        }
+
         other => return Err(format!("unknown dtype '{}' for column creation", other)),
     };
     Ok(pair)
 }
 
-// Helper trait to associate Rust native types with Arrow type markers.
-trait NativeTypeAlias {
-    type ArrowType: arrow_array::types::ArrowPrimitiveType;
-}
-impl NativeTypeAlias for i8 {
-    type ArrowType = Int8Type;
-}
-impl NativeTypeAlias for i16 {
-    type ArrowType = Int16Type;
-}
-impl NativeTypeAlias for i32 {
-    type ArrowType = Int32Type;
-}
-impl NativeTypeAlias for i64 {
-    type ArrowType = Int64Type;
-}
-impl NativeTypeAlias for u8 {
-    type ArrowType = UInt8Type;
-}
-impl NativeTypeAlias for u16 {
-    type ArrowType = UInt16Type;
-}
-impl NativeTypeAlias for u32 {
-    type ArrowType = UInt32Type;
-}
-impl NativeTypeAlias for u64 {
-    type ArrowType = UInt64Type;
-}
-impl NativeTypeAlias for f32 {
-    type ArrowType = Float32Type;
-}
-impl NativeTypeAlias for f64 {
-    type ArrowType = Float64Type;
+/// Decode a sequence of `length` length-prefixed records out of `bytes`.
+///
+/// Each record has the layout `<<len::u32-le, bytes::binary-size(len)>>`.
+/// Returns the decoded byte slices in order, or an error describing the
+/// malformed framing.
+fn decode_varlen_records<'a>(
+    bytes: &'a [u8],
+    length: usize,
+    dtype: &str,
+) -> Result<Vec<&'a [u8]>, String> {
+    let mut elems: Vec<&[u8]> = Vec::with_capacity(length);
+    let mut offset = 0usize;
+
+    for i in 0..length {
+        if offset + 4 > bytes.len() {
+            return Err(format!(
+                "binary truncated for {}: missing length prefix for element {} (offset {} of {} bytes)",
+                dtype,
+                i,
+                offset,
+                bytes.len()
+            ));
+        }
+        let len = u32::from_le_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ]) as usize;
+        offset += 4;
+        if offset + len > bytes.len() {
+            return Err(format!(
+                "binary truncated for {}: element {} declares {} bytes but only {} remain",
+                dtype,
+                i,
+                len,
+                bytes.len() - offset
+            ));
+        }
+        elems.push(&bytes[offset..offset + len]);
+        offset += len;
+    }
+
+    if offset != bytes.len() {
+        return Err(format!(
+            "binary length mismatch for {}: {} trailing bytes after {} elements",
+            dtype,
+            bytes.len() - offset,
+            length
+        ));
+    }
+
+    Ok(elems)
 }
 
 /// Write schema and record batches in IPC file format (random-access footer). Returns :ok or {:error, msg}.

--- a/native/ex_arrow_native/src/ipc.rs
+++ b/native/ex_arrow_native/src/ipc.rs
@@ -23,7 +23,10 @@ use arrow_ipc::writer::{FileWriter, StreamWriter};
 use rustler::ResourceArc;
 use rustler::{Encoder, Env, Term};
 
-use crate::resources::{ExArrowIpcFile, ExArrowIpcStream, ExArrowRecordBatch, ExArrowSchema, IpcFileBacking, IpcStreamBacking};
+use crate::resources::{
+    ExArrowIpcFile, ExArrowIpcStream, ExArrowRecordBatch, ExArrowSchema, IpcFileBacking,
+    IpcStreamBacking,
+};
 use crate::util::{err_encode, ok_encode};
 
 /// Builds a small IPC stream fixture (schema: id int64, name utf8; 2 rows) for tests.
@@ -188,7 +191,9 @@ fn data_type_to_atom(env: Env, dt: &arrow_schema::DataType) -> rustler::types::a
 
 /// Return the schema ref of a record batch.
 #[rustler::nif]
-pub fn record_batch_schema(batch: ResourceArc<ExArrowRecordBatch>) -> rustler::ResourceArc<ExArrowSchema> {
+pub fn record_batch_schema(
+    batch: ResourceArc<ExArrowRecordBatch>,
+) -> rustler::ResourceArc<ExArrowSchema> {
     let schema_handle = ExArrowSchema {
         schema: batch.batch.schema().clone(),
     };
@@ -221,9 +226,7 @@ pub fn ipc_stream_schema<'a>(env: Env<'a>, stream: ResourceArc<ExArrowIpcStream>
             guard.schema()
         }
     };
-    let schema_handle = ExArrowSchema {
-        schema: schema_ref,
-    };
+    let schema_handle = ExArrowSchema { schema: schema_ref };
     ResourceArc::new(schema_handle).encode(env)
 }
 
@@ -247,7 +250,9 @@ pub fn ipc_stream_next<'a>(env: Env<'a>, stream: ResourceArc<ExArrowIpcStream>) 
         }
     };
     match next_result {
-        None => rustler::types::atom::Atom::from_str(env, "done").unwrap().encode(env),
+        None => rustler::types::atom::Atom::from_str(env, "done")
+            .unwrap()
+            .encode(env),
         Some(Err(e)) => err_encode(env, &e.to_string()),
         Some(Ok(batch)) => {
             let handle = ExArrowRecordBatch { batch };
@@ -330,9 +335,7 @@ pub fn ipc_file_schema<'a>(env: Env<'a>, file: ResourceArc<ExArrowIpcFile>) -> T
             Err(_) => return err_encode(env, "file lock"),
         },
     };
-    let schema_handle = ExArrowSchema {
-        schema: schema_ref,
-    };
+    let schema_handle = ExArrowSchema { schema: schema_ref };
     ResourceArc::new(schema_handle).encode(env)
 }
 
@@ -415,7 +418,9 @@ pub fn ipc_writer_to_file<'a>(
     if let Err(e) = writer.finish() {
         return err_encode(env, &e.to_string());
     }
-    rustler::types::atom::Atom::from_str(env, "ok").unwrap().encode(env)
+    rustler::types::atom::Atom::from_str(env, "ok")
+        .unwrap()
+        .encode(env)
 }
 
 // ── Nx support NIFs ──────────────────────────────────────────────────────────
@@ -427,7 +432,7 @@ pub fn ipc_writer_to_file<'a>(
 /// `type_string` is one of `"s8"`, `"s16"`, `"s32"`, `"s64"`, `"u8"`, `"u16"`,
 /// `"u32"`, `"u64"`, `"f32"`, `"f64"`.  Float columns use IEEE 754 native byte order.
 ///
-/// Null/validity bitmaps are ignored — null positions are returned as zero bytes.
+/// Null/validity bitmaps are ignored; null positions are returned as zero bytes.
 #[rustler::nif]
 pub fn record_batch_column_buffer<'a>(
     env: Env<'a>,
@@ -457,9 +462,8 @@ macro_rules! primitive_buffer {
             std::mem::size_of::<<$ArrowType as arrow_array::types::ArrowPrimitiveType>::Native>();
         // SAFETY: slice is a valid aligned slice of a numeric primitive type whose
         // in-memory representation is exactly `len * byte_size` bytes.
-        let bytes: &[u8] = unsafe {
-            std::slice::from_raw_parts(slice.as_ptr() as *const u8, len * byte_size)
-        };
+        let bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, len * byte_size) };
         let mut owned = match rustler::OwnedBinary::new(bytes.len()) {
             Some(b) => b,
             None => return err_encode($env, "binary alloc"),
@@ -604,11 +608,11 @@ pub fn record_batch_concat<'a>(
 // Wire formats accepted by `build_column_array`:
 //
 // * Fixed-width primitives (s8..s64, u8..u64, f32, f64, date32, date64,
-//   timestamp_*, duration_*) — `length × element_size` bytes, little-endian
+//   timestamp_*, duration_*): `length × element_size` bytes, little-endian
 //   for multi-byte types.
-// * `bool` — exactly `length` bytes, one byte per element (0 = false,
+// * `bool`: exactly `length` bytes, one byte per element (0 = false,
 //   non-zero = true).
-// * `utf8`, `large_utf8`, `binary`, `large_binary` — concatenation of N
+// * `utf8`, `large_utf8`, `binary`, `large_binary`: concatenation of N
 //   length-prefixed records, each of the form
 //   `<<elem_len::u32-little, elem_bytes::binary-size(elem_len)>>`.
 
@@ -642,13 +646,13 @@ fn build_column_array(
 ) -> Result<(DataType, ArrayRef), String> {
     let pair = match dtype_str {
         // ── Signed integers ─────────────────────────────────────────
-        "s8"  => build_fixed_col!(bytes, length, i8,  Int8Type,  DataType::Int8),
+        "s8" => build_fixed_col!(bytes, length, i8, Int8Type, DataType::Int8),
         "s16" => build_fixed_col!(bytes, length, i16, Int16Type, DataType::Int16),
         "s32" => build_fixed_col!(bytes, length, i32, Int32Type, DataType::Int32),
         "s64" => build_fixed_col!(bytes, length, i64, Int64Type, DataType::Int64),
 
         // ── Unsigned integers ───────────────────────────────────────
-        "u8"  => build_fixed_col!(bytes, length, u8,  UInt8Type,  DataType::UInt8),
+        "u8" => build_fixed_col!(bytes, length, u8, UInt8Type, DataType::UInt8),
         "u16" => build_fixed_col!(bytes, length, u16, UInt16Type, DataType::UInt16),
         "u32" => build_fixed_col!(bytes, length, u32, UInt32Type, DataType::UInt32),
         "u64" => build_fixed_col!(bytes, length, u64, UInt64Type, DataType::UInt64),
@@ -680,36 +684,60 @@ fn build_column_array(
         "date64" => build_fixed_col!(bytes, length, i64, Date64Type, DataType::Date64),
 
         "timestamp_seconds" => build_fixed_col!(
-            bytes, length, i64, TimestampSecondType,
+            bytes,
+            length,
+            i64,
+            TimestampSecondType,
             DataType::Timestamp(TimeUnit::Second, None)
         ),
         "timestamp_millis" => build_fixed_col!(
-            bytes, length, i64, TimestampMillisecondType,
+            bytes,
+            length,
+            i64,
+            TimestampMillisecondType,
             DataType::Timestamp(TimeUnit::Millisecond, None)
         ),
         "timestamp_micros" => build_fixed_col!(
-            bytes, length, i64, TimestampMicrosecondType,
+            bytes,
+            length,
+            i64,
+            TimestampMicrosecondType,
             DataType::Timestamp(TimeUnit::Microsecond, None)
         ),
         "timestamp_nanos" => build_fixed_col!(
-            bytes, length, i64, TimestampNanosecondType,
+            bytes,
+            length,
+            i64,
+            TimestampNanosecondType,
             DataType::Timestamp(TimeUnit::Nanosecond, None)
         ),
 
         "duration_seconds" => build_fixed_col!(
-            bytes, length, i64, DurationSecondType,
+            bytes,
+            length,
+            i64,
+            DurationSecondType,
             DataType::Duration(TimeUnit::Second)
         ),
         "duration_millis" => build_fixed_col!(
-            bytes, length, i64, DurationMillisecondType,
+            bytes,
+            length,
+            i64,
+            DurationMillisecondType,
             DataType::Duration(TimeUnit::Millisecond)
         ),
         "duration_micros" => build_fixed_col!(
-            bytes, length, i64, DurationMicrosecondType,
+            bytes,
+            length,
+            i64,
+            DurationMicrosecondType,
             DataType::Duration(TimeUnit::Microsecond)
         ),
         "duration_nanos" => build_fixed_col!(
-            bytes, length, i64, DurationNanosecondType,
+            bytes,
+            length,
+            i64,
+            DurationNanosecondType,
             DataType::Duration(TimeUnit::Nanosecond)
         ),
 
@@ -734,8 +762,9 @@ fn build_column_array(
         }
         "binary" => {
             let elems = decode_varlen_records(bytes, length, "binary")?;
-            let array: ArrayRef =
-                Arc::new(BinaryArray::from(elems.iter().map(|e| e.as_ref()).collect::<Vec<&[u8]>>()));
+            let array: ArrayRef = Arc::new(BinaryArray::from(
+                elems.iter().map(|e| e.as_ref()).collect::<Vec<&[u8]>>(),
+            ));
             (DataType::Binary, array)
         }
         "large_binary" => {
@@ -830,5 +859,7 @@ pub fn ipc_file_writer_to_file<'a>(
     if let Err(e) = writer.finish() {
         return err_encode(env, &e.to_string());
     }
-    rustler::types::atom::Atom::from_str(env, "ok").unwrap().encode(env)
+    rustler::types::atom::Atom::from_str(env, "ok")
+        .unwrap()
+        .encode(env)
 }

--- a/native/ex_arrow_native/src/parquet.rs
+++ b/native/ex_arrow_native/src/parquet.rs
@@ -62,10 +62,7 @@ pub fn parquet_reader_from_binary<'a>(env: Env<'a>, binary: rustler::Binary) -> 
     build_stream(env, builder)
 }
 
-fn build_stream<'a, T>(
-    env: Env<'a>,
-    builder: ParquetRecordBatchReaderBuilder<T>,
-) -> Term<'a>
+fn build_stream<'a, T>(env: Env<'a>, builder: ParquetRecordBatchReaderBuilder<T>) -> Term<'a>
 where
     T: parquet::file::reader::ChunkReader + 'static,
 {

--- a/script/check_version
+++ b/script/check_version
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Assert that the top "## [x.y.z]" version in CHANGELOG.md matches the
+# @version attribute in mix.exs.  Run by CI to prevent shipping a release
+# whose version markers disagree.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+mix_version=$(grep -E '^[[:space:]]*@version[[:space:]]+"' mix.exs | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+changelog_version=$(grep -E '^##[[:space:]]+\[[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1 | sed -E 's/^##[[:space:]]+\[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')
+
+if [ -z "$mix_version" ]; then
+  echo "::error::could not parse @version from mix.exs"
+  exit 1
+fi
+
+if [ -z "$changelog_version" ]; then
+  echo "::error::could not parse top version from CHANGELOG.md"
+  exit 1
+fi
+
+if [ "$mix_version" != "$changelog_version" ]; then
+  echo "::error::version mismatch: mix.exs @version=\"$mix_version\" but CHANGELOG.md top entry is [$changelog_version]"
+  exit 1
+fi
+
+echo "version OK: $mix_version"

--- a/script/ci
+++ b/script/ci
@@ -15,6 +15,8 @@ echo "== mix credo --strict"
 mix credo --strict
 echo "== mix sobelow"
 mix sobelow --exit --skip
+echo "== check_version"
+bash script/check_version
 echo "== mix dialyzer"
 mix dialyzer
 echo "== mix test"

--- a/script/ci
+++ b/script/ci
@@ -22,5 +22,5 @@ mix test
 echo "== mix coveralls.html"
 mix coveralls.html  --include adbc_package:true
 echo "== mix docs"
-mix docs --warninsg-as-errors
+mix docs --warnings-as-errors
 echo "== CI (local) passed"

--- a/test/ex_arrow/flight_sql_integration_test.exs
+++ b/test/ex_arrow/flight_sql_integration_test.exs
@@ -183,8 +183,9 @@ defmodule ExArrow.FlightSQL.IntegrationTest do
 
       with_stmt(client, "SELECT 1 AS n", fn stmt ->
         case Statement.parameter_schema(stmt) do
-          {:ok, %ExArrow.Schema{}} ->
-            :ok
+          {:ok, %ExArrow.Schema{} = schema} ->
+            # Parameter-less queries should produce an empty parameter schema.
+            assert ExArrow.Schema.fields(schema) == []
 
           {:error, %Error{code: code}} ->
             # Some servers don't expose a parameter schema for parameter-less
@@ -194,14 +195,32 @@ defmodule ExArrow.FlightSQL.IntegrationTest do
       end)
     end
 
-    test "returns a Schema describing a single ? placeholder" do
+    test "describes a single ? placeholder with one Field" do
       client = connect()
 
       with_stmt(client, "SELECT ? AS x", fn stmt ->
         case Statement.parameter_schema(stmt) do
           {:ok, %ExArrow.Schema{} = schema} ->
             fields = ExArrow.Schema.fields(schema)
-            assert length(fields) >= 1
+            assert length(fields) == 1
+            [field] = fields
+            assert %ExArrow.Field{} = field
+            assert is_binary(field.name)
+            assert is_atom(field.type)
+
+          {:error, %Error{code: code}} ->
+            assert code in [:unimplemented, :invalid_argument]
+        end
+      end)
+    end
+
+    test "describes two ? placeholders with two Fields" do
+      client = connect()
+
+      with_stmt(client, "SELECT ? AS x, ? AS y", fn stmt ->
+        case Statement.parameter_schema(stmt) do
+          {:ok, %ExArrow.Schema{} = schema} ->
+            assert length(ExArrow.Schema.fields(schema)) == 2
 
           {:error, %Error{code: code}} ->
             assert code in [:unimplemented, :invalid_argument]
@@ -250,6 +269,25 @@ defmodule ExArrow.FlightSQL.IntegrationTest do
             assert code in [:unimplemented, :invalid_argument]
 
           {_, {:error, %Error{code: code}}} ->
+            assert code in [:unimplemented, :invalid_argument]
+        end
+      end)
+    end
+
+    test "binds a utf8 parameter built via from_columns/4 (length-prefixed wire format)" do
+      client = connect()
+
+      with_stmt(client, "SELECT ? AS s", fn stmt ->
+        # Two strings, length-prefixed.
+        utf8 = <<5::little-32, "hello", 5::little-32, "world">>
+        {:ok, params} = RecordBatch.from_columns(["s"], [utf8], ["utf8"], 2)
+
+        case Statement.bind(stmt, params) do
+          :ok ->
+            assert {:ok, stream} = Statement.execute(stmt)
+            assert length(Enum.to_list(stream)) >= 1
+
+          {:error, %Error{code: code}} ->
             assert code in [:unimplemented, :invalid_argument]
         end
       end)

--- a/test/ex_arrow/flight_sql_integration_test.exs
+++ b/test/ex_arrow/flight_sql_integration_test.exs
@@ -25,7 +25,8 @@ defmodule ExArrow.FlightSQL.IntegrationTest do
   """
 
   use ExUnit.Case
-  alias ExArrow.FlightSQL.{Client, Error}
+  alias ExArrow.FlightSQL.{Client, Error, Statement}
+  alias ExArrow.RecordBatch
 
   @moduletag :flight_sql_integration
 
@@ -146,15 +147,160 @@ defmodule ExArrow.FlightSQL.IntegrationTest do
 
   # ── Prepared statements ───────────────────────────────────────────────────────
 
+  # Skip the body when the server does not implement prepared statements.
+  defp with_stmt(client, sql, fun) do
+    case Client.prepare(client, sql) do
+      {:ok, stmt} ->
+        try do
+          fun.(stmt)
+        after
+          # Best-effort cleanup; close errors here are not test failures.
+          _ = Statement.close(stmt)
+        end
+
+      {:error, %Error{code: :unimplemented}} ->
+        :ok
+    end
+  end
+
   describe "prepare/2 + Statement.execute/1" do
     test "prepares and executes a SELECT" do
       client = connect()
 
+      with_stmt(client, "SELECT 1 AS n", fn stmt ->
+        assert {:ok, stream} = Statement.execute(stmt)
+        batches = Enum.to_list(stream)
+        assert length(batches) >= 1
+      end)
+    end
+  end
+
+  # ── Statement.parameter_schema/1 ─────────────────────────────────────────────
+
+  describe "Statement.parameter_schema/1" do
+    test "returns a Schema for a statement with no parameters" do
+      client = connect()
+
+      with_stmt(client, "SELECT 1 AS n", fn stmt ->
+        case Statement.parameter_schema(stmt) do
+          {:ok, %ExArrow.Schema{}} ->
+            :ok
+
+          {:error, %Error{code: code}} ->
+            # Some servers don't expose a parameter schema for parameter-less
+            # queries; accept :unimplemented or :invalid_argument.
+            assert code in [:unimplemented, :invalid_argument]
+        end
+      end)
+    end
+
+    test "returns a Schema describing a single ? placeholder" do
+      client = connect()
+
+      with_stmt(client, "SELECT ? AS x", fn stmt ->
+        case Statement.parameter_schema(stmt) do
+          {:ok, %ExArrow.Schema{} = schema} ->
+            fields = ExArrow.Schema.fields(schema)
+            assert length(fields) >= 1
+
+          {:error, %Error{code: code}} ->
+            assert code in [:unimplemented, :invalid_argument]
+        end
+      end)
+    end
+  end
+
+  # ── Statement.bind/2 ────────────────────────────────────────────────────────
+
+  describe "Statement.bind/2 + Statement.execute/1" do
+    test "binds an int64 parameter and executes" do
+      client = connect()
+
+      with_stmt(client, "SELECT ? AS x", fn stmt ->
+        {:ok, params} =
+          RecordBatch.from_columns(["x"], [<<42::little-signed-64>>], ["s64"], 1)
+
+        case Statement.bind(stmt, params) do
+          :ok ->
+            assert {:ok, stream} = Statement.execute(stmt)
+            batches = Enum.to_list(stream)
+            assert length(batches) >= 1
+
+          {:error, %Error{code: code}} ->
+            # Servers that don't accept bind for ad-hoc placeholders
+            # may return :unimplemented or :invalid_argument.
+            assert code in [:unimplemented, :invalid_argument]
+        end
+      end)
+    end
+
+    test "rebinding replaces previous parameters" do
+      client = connect()
+
+      with_stmt(client, "SELECT ? AS x", fn stmt ->
+        {:ok, p1} = RecordBatch.from_columns(["x"], [<<1::little-signed-64>>], ["s64"], 1)
+        {:ok, p2} = RecordBatch.from_columns(["x"], [<<2::little-signed-64>>], ["s64"], 1)
+
+        case {Statement.bind(stmt, p1), Statement.bind(stmt, p2)} do
+          {:ok, :ok} ->
+            assert {:ok, stream} = Statement.execute(stmt)
+            assert length(Enum.to_list(stream)) >= 1
+
+          {{:error, %Error{code: code}}, _} ->
+            assert code in [:unimplemented, :invalid_argument]
+
+          {_, {:error, %Error{code: code}}} ->
+            assert code in [:unimplemented, :invalid_argument]
+        end
+      end)
+    end
+  end
+
+  # ── Statement.close/1 lifecycle ─────────────────────────────────────────────
+
+  describe "Statement.close/1" do
+    test "explicit close after execute returns :ok" do
+      client = connect()
+
       case Client.prepare(client, "SELECT 1 AS n") do
         {:ok, stmt} ->
-          assert {:ok, stream} = ExArrow.FlightSQL.Statement.execute(stmt)
-          batches = Enum.to_list(stream)
-          assert length(batches) >= 1
+          assert {:ok, _stream} = Statement.execute(stmt)
+          assert :ok = Statement.close(stmt)
+
+        {:error, %Error{code: :unimplemented}} ->
+          :ok
+      end
+    end
+
+    test "operations on a closed statement return :protocol_error" do
+      client = connect()
+
+      case Client.prepare(client, "SELECT 1 AS n") do
+        {:ok, stmt} ->
+          assert :ok = Statement.close(stmt)
+
+          assert {:error, %Error{code: :protocol_error}} = Statement.execute(stmt)
+          assert {:error, %Error{code: :protocol_error}} = Statement.execute_update(stmt)
+          assert {:error, %Error{code: :protocol_error}} = Statement.parameter_schema(stmt)
+
+          {:ok, params} =
+            RecordBatch.from_columns(["x"], [<<1::little-signed-64>>], ["s64"], 1)
+
+          assert {:error, %Error{code: :protocol_error}} = Statement.bind(stmt, params)
+
+        {:error, %Error{code: :unimplemented}} ->
+          :ok
+      end
+    end
+
+    test "close is idempotent" do
+      client = connect()
+
+      case Client.prepare(client, "SELECT 1 AS n") do
+        {:ok, stmt} ->
+          assert :ok = Statement.close(stmt)
+          assert :ok = Statement.close(stmt)
+          assert :ok = Statement.close(stmt)
 
         {:error, %Error{code: :unimplemented}} ->
           :ok

--- a/test/ex_arrow/flight_sql_statement_test.exs
+++ b/test/ex_arrow/flight_sql_statement_test.exs
@@ -24,21 +24,14 @@ defmodule ExArrow.FlightSQL.StatementTest do
   defp restore(key, val), do: Application.put_env(:ex_arrow, key, val)
 
   defp fake_stmt, do: %Statement{resource: make_ref()}
-  defp fake_closed_stmt, do: %Statement{resource: make_ref(), closed: true}
 
   # ── Statement struct ─────────────────────────────────────────────────────────
 
   describe "struct" do
-    test "holds a resource ref and defaults to open" do
+    test "holds a resource ref" do
       ref = make_ref()
       stmt = %Statement{resource: ref}
       assert stmt.resource == ref
-      assert stmt.closed == false
-    end
-
-    test "closed field tracks close state" do
-      stmt = %Statement{resource: make_ref(), closed: true}
-      assert stmt.closed == true
     end
   end
 
@@ -98,10 +91,20 @@ defmodule ExArrow.FlightSQL.StatementTest do
     end
   end
 
-  describe "execute/1 — closed statement" do
+  describe "execute/1 — closed statement (NIF returns :protocol_error)" do
+    setup do
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeClosed
+      )
+
+      :ok
+    end
+
     test "returns {:error, %Error{code: :protocol_error}}" do
       assert {:error, %Error{code: :protocol_error, message: msg}} =
-               Statement.execute(fake_closed_stmt())
+               Statement.execute(fake_stmt())
 
       assert msg =~ "statement is closed"
     end
@@ -177,10 +180,19 @@ defmodule ExArrow.FlightSQL.StatementTest do
     end
   end
 
-  describe "execute_update/1 — closed statement" do
+  describe "execute_update/1 — closed statement (NIF returns :protocol_error)" do
+    setup do
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeClosed
+      )
+
+      :ok
+    end
+
     test "returns {:error, %Error{code: :protocol_error}}" do
-      assert {:error, %Error{code: :protocol_error}} =
-               Statement.execute_update(fake_closed_stmt())
+      assert {:error, %Error{code: :protocol_error}} = Statement.execute_update(fake_stmt())
     end
   end
 
@@ -219,12 +231,22 @@ defmodule ExArrow.FlightSQL.StatementTest do
     end
   end
 
-  describe "bind/2 — closed statement" do
+  describe "bind/2 — closed statement (NIF returns :protocol_error)" do
+    setup do
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeClosed
+      )
+
+      :ok
+    end
+
     test "returns {:error, %Error{code: :protocol_error}}" do
       batch = %ExArrow.RecordBatch{resource: make_ref()}
 
       assert {:error, %Error{code: :protocol_error, message: msg}} =
-               Statement.bind(fake_closed_stmt(), batch)
+               Statement.bind(fake_stmt(), batch)
 
       assert msg =~ "statement is closed"
     end
@@ -262,10 +284,19 @@ defmodule ExArrow.FlightSQL.StatementTest do
     end
   end
 
-  describe "parameter_schema/1 — closed statement" do
+  describe "parameter_schema/1 — closed statement (NIF returns :protocol_error)" do
+    setup do
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeClosed
+      )
+
+      :ok
+    end
+
     test "returns {:error, %Error{code: :protocol_error}}" do
-      assert {:error, %Error{code: :protocol_error}} =
-               Statement.parameter_schema(fake_closed_stmt())
+      assert {:error, %Error{code: :protocol_error}} = Statement.parameter_schema(fake_stmt())
     end
   end
 
@@ -278,15 +309,26 @@ defmodule ExArrow.FlightSQL.StatementTest do
     end
 
     test "returns :ok" do
-      stmt = fake_stmt()
-      assert :ok = Statement.close(stmt)
+      assert :ok = Statement.close(fake_stmt())
     end
   end
 
-  describe "close/1 — idempotent" do
-    test "calling close twice returns :ok" do
-      stmt = %Statement{resource: make_ref(), closed: true}
-      assert :ok = Statement.close(stmt)
+  describe "close/1 — idempotent (NIF reports already-closed as :ok)" do
+    setup do
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeClosed
+      )
+
+      :ok
+    end
+
+    test "second close call returns :ok" do
+      # Closed-state lives inside the NIF resource; the stub returns :ok
+      # to model the idempotent behaviour of the real NIF when the inner
+      # Option<PreparedStatement> has already been taken.
+      assert :ok = Statement.close(fake_stmt())
     end
   end
 
@@ -324,28 +366,35 @@ defmodule ExArrow.FlightSQL.StatementTest do
     end
   end
 
-  # ── Operations after close should fail ────────────────────────────────────────
+  # ── Operations after close should fail (NIF-side guard) ──────────────────────
 
-  describe "operations after close" do
-    test "bind after close returns protocol error" do
+  describe "operations after close (NIF guard)" do
+    setup do
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeClosed
+      )
+
+      :ok
+    end
+
+    test "bind on closed stmt returns protocol error" do
       batch = %ExArrow.RecordBatch{resource: make_ref()}
 
-      assert {:error, %Error{code: :protocol_error}} =
-               Statement.bind(fake_closed_stmt(), batch)
+      assert {:error, %Error{code: :protocol_error}} = Statement.bind(fake_stmt(), batch)
     end
 
-    test "execute after close returns protocol error" do
-      assert {:error, %Error{code: :protocol_error}} = Statement.execute(fake_closed_stmt())
+    test "execute on closed stmt returns protocol error" do
+      assert {:error, %Error{code: :protocol_error}} = Statement.execute(fake_stmt())
     end
 
-    test "execute_update after close returns protocol error" do
-      assert {:error, %Error{code: :protocol_error}} =
-               Statement.execute_update(fake_closed_stmt())
+    test "execute_update on closed stmt returns protocol error" do
+      assert {:error, %Error{code: :protocol_error}} = Statement.execute_update(fake_stmt())
     end
 
-    test "parameter_schema after close returns protocol error" do
-      assert {:error, %Error{code: :protocol_error}} =
-               Statement.parameter_schema(fake_closed_stmt())
+    test "parameter_schema on closed stmt returns protocol error" do
+      assert {:error, %Error{code: :protocol_error}} = Statement.parameter_schema(fake_stmt())
     end
   end
 

--- a/test/ex_arrow/flight_sql_statement_test.exs
+++ b/test/ex_arrow/flight_sql_statement_test.exs
@@ -208,6 +208,36 @@ defmodule ExArrow.FlightSQL.StatementTest do
       batch = %ExArrow.RecordBatch{resource: make_ref()}
       assert :ok = Statement.bind(fake_stmt(), batch)
     end
+
+    test "accepts a real RecordBatch built via from_columns/4 and forwards its resource ref" do
+      # End-to-end at the Elixir layer:
+      #   from_columns/4 produces a real NIF reference,
+      #   Statement.bind/2 unwraps the struct via pattern match,
+      #   the recording stub captures the exact ref it was handed.
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeRecording
+      )
+
+      ExArrow.FlightSQL.StmtNativeRecording.reset()
+
+      assert {:ok, %ExArrow.RecordBatch{resource: batch_ref} = batch} =
+               ExArrow.RecordBatch.from_columns(
+                 ["id"],
+                 [<<42::little-signed-64>>],
+                 ["s64"],
+                 1
+               )
+
+      assert is_reference(batch_ref)
+
+      stmt = fake_stmt()
+      assert :ok = Statement.bind(stmt, batch)
+
+      assert ExArrow.FlightSQL.StmtNativeRecording.last_bind_call() ==
+               {stmt.resource, batch_ref}
+    end
   end
 
   describe "bind/2 — schema mismatch error" do

--- a/test/ex_arrow/flight_sql_statement_test.exs
+++ b/test/ex_arrow/flight_sql_statement_test.exs
@@ -313,22 +313,52 @@ defmodule ExArrow.FlightSQL.StatementTest do
     end
   end
 
-  describe "close/1 — idempotent (NIF reports already-closed as :ok)" do
-    setup do
+  describe "close/1 — idempotent" do
+    test "open → close → close (counts both invocations, both succeed)" do
+      # Use a stateful stub that flips its closed-state after the first
+      # successful close call, so the second invocation hits the
+      # already-closed branch and still returns :ok.
       Application.put_env(
         :ex_arrow,
         :flight_sql_statement_native,
-        ExArrow.FlightSQL.StmtNativeClosed
+        ExArrow.FlightSQL.StmtNativeStatefulClose
       )
 
-      :ok
+      ExArrow.FlightSQL.StmtNativeStatefulClose.reset()
+
+      stmt = fake_stmt()
+
+      assert :ok = Statement.close(stmt)
+      assert :ok = Statement.close(stmt)
+
+      assert ExArrow.FlightSQL.StmtNativeStatefulClose.call_count() == 2
+      assert ExArrow.FlightSQL.StmtNativeStatefulClose.closed?()
     end
 
-    test "second close call returns :ok" do
-      # Closed-state lives inside the NIF resource; the stub returns :ok
-      # to model the idempotent behaviour of the real NIF when the inner
-      # Option<PreparedStatement> has already been taken.
-      assert :ok = Statement.close(fake_stmt())
+    test "operations after close return :protocol_error (full lifecycle)" do
+      # Stateful stub: first close returns :ok, then everything else (including
+      # subsequent close, bind, execute, ...) returns :protocol_error from the
+      # NIF — modelling the real NIF's Mutex<Option<...>>::take() behaviour.
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeStatefulClose
+      )
+
+      ExArrow.FlightSQL.StmtNativeStatefulClose.reset()
+
+      stmt = fake_stmt()
+      batch = %ExArrow.RecordBatch{resource: make_ref()}
+
+      assert :ok = Statement.close(stmt)
+
+      assert {:error, %Error{code: :protocol_error}} = Statement.bind(stmt, batch)
+      assert {:error, %Error{code: :protocol_error}} = Statement.execute(stmt)
+      assert {:error, %Error{code: :protocol_error}} = Statement.execute_update(stmt)
+      assert {:error, %Error{code: :protocol_error}} = Statement.parameter_schema(stmt)
+
+      # close/1 itself is still idempotent and returns :ok.
+      assert :ok = Statement.close(stmt)
     end
   end
 

--- a/test/ex_arrow/flight_sql_statement_test.exs
+++ b/test/ex_arrow/flight_sql_statement_test.exs
@@ -24,14 +24,21 @@ defmodule ExArrow.FlightSQL.StatementTest do
   defp restore(key, val), do: Application.put_env(:ex_arrow, key, val)
 
   defp fake_stmt, do: %Statement{resource: make_ref()}
+  defp fake_closed_stmt, do: %Statement{resource: make_ref(), closed: true}
 
   # ── Statement struct ─────────────────────────────────────────────────────────
 
   describe "struct" do
-    test "holds a resource ref" do
+    test "holds a resource ref and defaults to open" do
       ref = make_ref()
       stmt = %Statement{resource: ref}
       assert stmt.resource == ref
+      assert stmt.closed == false
+    end
+
+    test "closed field tracks close state" do
+      stmt = %Statement{resource: make_ref(), closed: true}
+      assert stmt.closed == true
     end
   end
 
@@ -85,8 +92,18 @@ defmodule ExArrow.FlightSQL.StatementTest do
   end
 
   describe "execute/1 — invalid resource (real NIF)" do
-    test "raises ArgumentError when resource is a plain Erlang ref" do
+    @tag no_nif: true
+    test "raises ArgumentError when NIF is loaded with bad ref" do
       assert_raise ArgumentError, fn -> Statement.execute(fake_stmt()) end
+    end
+  end
+
+  describe "execute/1 — closed statement" do
+    test "returns {:error, %Error{code: :protocol_error}}" do
+      assert {:error, %Error{code: :protocol_error, message: msg}} =
+               Statement.execute(fake_closed_stmt())
+
+      assert msg =~ "statement is closed"
     end
   end
 
@@ -154,8 +171,181 @@ defmodule ExArrow.FlightSQL.StatementTest do
   end
 
   describe "execute_update/1 — invalid resource (real NIF)" do
-    test "raises ArgumentError when resource is a plain Erlang ref" do
+    @tag no_nif: true
+    test "raises ArgumentError when NIF is loaded with bad ref" do
       assert_raise ArgumentError, fn -> Statement.execute_update(fake_stmt()) end
+    end
+  end
+
+  describe "execute_update/1 — closed statement" do
+    test "returns {:error, %Error{code: :protocol_error}}" do
+      assert {:error, %Error{code: :protocol_error}} =
+               Statement.execute_update(fake_closed_stmt())
+    end
+  end
+
+  # ── Statement.bind/2 ─────────────────────────────────────────────────────────
+
+  describe "bind/2 — success (stub native)" do
+    setup do
+      Application.put_env(:ex_arrow, :flight_sql_statement_native, ExArrow.FlightSQL.StmtNativeOk)
+      :ok
+    end
+
+    test "returns :ok" do
+      batch = %ExArrow.RecordBatch{resource: make_ref()}
+      assert :ok = Statement.bind(fake_stmt(), batch)
+    end
+  end
+
+  describe "bind/2 — schema mismatch error" do
+    setup do
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeError
+      )
+
+      :ok
+    end
+
+    test "returns {:error, %Error{code: :invalid_argument}}" do
+      batch = %ExArrow.RecordBatch{resource: make_ref()}
+
+      assert {:error, %Error{code: :invalid_argument, message: msg}} =
+               Statement.bind(fake_stmt(), batch)
+
+      assert msg =~ "schema mismatch"
+    end
+  end
+
+  describe "bind/2 — closed statement" do
+    test "returns {:error, %Error{code: :protocol_error}}" do
+      batch = %ExArrow.RecordBatch{resource: make_ref()}
+
+      assert {:error, %Error{code: :protocol_error, message: msg}} =
+               Statement.bind(fake_closed_stmt(), batch)
+
+      assert msg =~ "statement is closed"
+    end
+  end
+
+  # ── Statement.parameter_schema/1 ─────────────────────────────────────────────
+
+  describe "parameter_schema/1 — success (stub native)" do
+    setup do
+      Application.put_env(:ex_arrow, :flight_sql_statement_native, ExArrow.FlightSQL.StmtNativeOk)
+      :ok
+    end
+
+    test "returns {:ok, schema_ref}" do
+      assert {:ok, _schema} = Statement.parameter_schema(fake_stmt())
+    end
+  end
+
+  describe "parameter_schema/1 — unimplemented error" do
+    setup do
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeError
+      )
+
+      :ok
+    end
+
+    test "returns {:error, %Error{code: :unimplemented}}" do
+      assert {:error, %Error{code: :unimplemented, message: msg}} =
+               Statement.parameter_schema(fake_stmt())
+
+      assert msg =~ "parameter schema not available"
+    end
+  end
+
+  describe "parameter_schema/1 — closed statement" do
+    test "returns {:error, %Error{code: :protocol_error}}" do
+      assert {:error, %Error{code: :protocol_error}} =
+               Statement.parameter_schema(fake_closed_stmt())
+    end
+  end
+
+  # ── Statement.close/1 ───────────────────────────────────────────────────────
+
+  describe "close/1 — success (stub native)" do
+    setup do
+      Application.put_env(:ex_arrow, :flight_sql_statement_native, ExArrow.FlightSQL.StmtNativeOk)
+      :ok
+    end
+
+    test "returns :ok" do
+      stmt = fake_stmt()
+      assert :ok = Statement.close(stmt)
+    end
+  end
+
+  describe "close/1 — idempotent" do
+    test "calling close twice returns :ok" do
+      stmt = %Statement{resource: make_ref(), closed: true}
+      assert :ok = Statement.close(stmt)
+    end
+  end
+
+  describe "close/1 — server error (stub native)" do
+    setup do
+      Application.put_env(
+        :ex_arrow,
+        :flight_sql_statement_native,
+        ExArrow.FlightSQL.StmtNativeError
+      )
+
+      :ok
+    end
+
+    test "returns {:error, %Error{}} when server fails" do
+      assert {:error, %Error{}} = Statement.close(fake_stmt())
+    end
+  end
+
+  # ── Lifecycle: bind → execute → close ────────────────────────────────────────
+
+  describe "lifecycle — bind, execute, close" do
+    setup do
+      Application.put_env(:ex_arrow, :flight_sql_statement_native, ExArrow.FlightSQL.StmtNativeOk)
+      :ok
+    end
+
+    test "full lifecycle works with stubs" do
+      stmt = fake_stmt()
+      batch = %ExArrow.RecordBatch{resource: make_ref()}
+
+      assert :ok = Statement.bind(stmt, batch)
+      assert {:ok, %Stream{}} = Statement.execute(stmt)
+      assert :ok = Statement.close(stmt)
+    end
+  end
+
+  # ── Operations after close should fail ────────────────────────────────────────
+
+  describe "operations after close" do
+    test "bind after close returns protocol error" do
+      batch = %ExArrow.RecordBatch{resource: make_ref()}
+
+      assert {:error, %Error{code: :protocol_error}} =
+               Statement.bind(fake_closed_stmt(), batch)
+    end
+
+    test "execute after close returns protocol error" do
+      assert {:error, %Error{code: :protocol_error}} = Statement.execute(fake_closed_stmt())
+    end
+
+    test "execute_update after close returns protocol error" do
+      assert {:error, %Error{code: :protocol_error}} =
+               Statement.execute_update(fake_closed_stmt())
+    end
+
+    test "parameter_schema after close returns protocol error" do
+      assert {:error, %Error{code: :protocol_error}} =
+               Statement.parameter_schema(fake_closed_stmt())
     end
   end
 
@@ -200,7 +390,8 @@ defmodule ExArrow.FlightSQL.StatementTest do
   end
 
   describe "Client.prepare/2 — invalid resource (real NIF)" do
-    test "raises ArgumentError when client ref is a plain Erlang ref" do
+    @tag no_nif: true
+    test "raises ArgumentError when NIF is loaded with bad ref" do
       fake_client = %Client{resource: make_ref()}
 
       assert_raise ArgumentError, fn ->

--- a/test/ex_arrow/record_batch_test.exs
+++ b/test/ex_arrow/record_batch_test.exs
@@ -201,4 +201,137 @@ defmodule ExArrow.RecordBatchTest do
       assert msg =~ "binary length mismatch"
     end
   end
+
+  describe "from_columns/4 — date and time dtypes" do
+    test "date32 (i32 days since epoch)" do
+      bin = <<19_000::little-signed-32, 19_001::little-signed-32>>
+
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(["d"], [bin], ["date32"], 2)
+
+      assert RecordBatch.num_rows(batch) == 2
+    end
+
+    test "date64 (i64 millis since epoch)" do
+      bin = <<1_700_000_000_000::little-signed-64>>
+
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(["d"], [bin], ["date64"], 1)
+
+      assert RecordBatch.num_rows(batch) == 1
+    end
+
+    test "timestamp dtypes (all four time units)" do
+      ts_bin = <<1_700_000_000_000_000::little-signed-64>>
+
+      for dtype <- ~w(timestamp_seconds timestamp_millis timestamp_micros timestamp_nanos) do
+        assert {:ok, %RecordBatch{} = batch} =
+                 RecordBatch.from_columns(["t"], [ts_bin], [dtype], 1),
+               "expected dtype #{dtype} to succeed"
+
+        assert RecordBatch.num_rows(batch) == 1
+      end
+    end
+
+    test "duration dtypes (all four time units)" do
+      d_bin = <<3_600::little-signed-64>>
+
+      for dtype <- ~w(duration_seconds duration_millis duration_micros duration_nanos) do
+        assert {:ok, %RecordBatch{} = batch} =
+                 RecordBatch.from_columns(["d"], [d_bin], [dtype], 1),
+               "expected dtype #{dtype} to succeed"
+
+        assert RecordBatch.num_rows(batch) == 1
+      end
+    end
+
+    test "date32 reports binary length mismatch" do
+      assert {:error, msg} =
+               RecordBatch.from_columns(["d"], [<<1::little-signed-32>>], ["date32"], 2)
+
+      assert msg =~ "binary length mismatch"
+    end
+  end
+
+  describe "from_columns/4 — variable-length string and binary dtypes" do
+    # Wire format: <<elem_len::little-32, elem_bytes::binary-size(elem_len)>> × length
+    defp varlen([]), do: <<>>
+
+    defp varlen([head | tail]) when is_binary(head) do
+      <<byte_size(head)::little-32, head::binary, varlen(tail)::binary>>
+    end
+
+    test "utf8 with multiple elements" do
+      bin = varlen(["hello", "world", ""])
+
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(["s"], [bin], ["utf8"], 3)
+
+      assert RecordBatch.num_rows(batch) == 3
+    end
+
+    test "large_utf8 accepts the same wire format" do
+      bin = varlen(["a", "bb", "ccc"])
+
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(["s"], [bin], ["large_utf8"], 3)
+
+      assert RecordBatch.num_rows(batch) == 3
+    end
+
+    test "binary accepts arbitrary bytes" do
+      bin = varlen([<<0, 1, 2>>, <<255, 254>>])
+
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(["b"], [bin], ["binary"], 2)
+
+      assert RecordBatch.num_rows(batch) == 2
+    end
+
+    test "large_binary accepts arbitrary bytes" do
+      bin = varlen([<<0xFF, 0xFE>>])
+
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(["b"], [bin], ["large_binary"], 1)
+
+      assert RecordBatch.num_rows(batch) == 1
+    end
+
+    test "empty utf8 column" do
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(["s"], [<<>>], ["utf8"], 0)
+
+      assert RecordBatch.num_rows(batch) == 0
+    end
+
+    test "utf8 rejects invalid utf-8 bytes" do
+      bin = varlen([<<0xFF, 0xFE>>])
+
+      assert {:error, msg} = RecordBatch.from_columns(["s"], [bin], ["utf8"], 1)
+      assert msg =~ "invalid utf-8"
+    end
+
+    test "utf8 rejects truncated length prefix" do
+      # Declares a 4-byte length but provides only 2 bytes of header data.
+      bin = <<10::little-32, "ab">>
+
+      assert {:error, msg} = RecordBatch.from_columns(["s"], [bin], ["utf8"], 1)
+      assert msg =~ "truncated"
+    end
+
+    test "utf8 rejects trailing bytes after the declared element count" do
+      bin = varlen(["a"]) <> <<0::little-32>>
+
+      assert {:error, msg} = RecordBatch.from_columns(["s"], [bin], ["utf8"], 1)
+      assert msg =~ "trailing bytes"
+    end
+
+    test "binary rejects truncated payload" do
+      # Declares 5 bytes for the first element but provides only 3.
+      bin = <<5::little-32, "abc">>
+
+      assert {:error, msg} = RecordBatch.from_columns(["b"], [bin], ["binary"], 1)
+      assert msg =~ "truncated"
+    end
+  end
 end

--- a/test/ex_arrow/record_batch_test.exs
+++ b/test/ex_arrow/record_batch_test.exs
@@ -62,4 +62,143 @@ defmodule ExArrow.RecordBatchTest do
       assert msg =~ "empty"
     end
   end
+
+  describe "from_columns/4 — happy path" do
+    test "single s64 column, one row" do
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(["id"], [<<42::little-signed-64>>], ["s64"], 1)
+
+      assert RecordBatch.num_rows(batch) == 1
+      assert RecordBatch.num_columns(batch) == 1
+      assert RecordBatch.column_names(batch) == ["id"]
+    end
+
+    test "multi-row s64 column" do
+      bin =
+        <<1::little-signed-64, 2::little-signed-64, 3::little-signed-64, 4::little-signed-64>>
+
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(["x"], [bin], ["s64"], 4)
+
+      assert RecordBatch.num_rows(batch) == 4
+    end
+
+    test "all signed integer dtypes" do
+      cases = [
+        {"s8", <<7::signed-8>>},
+        {"s16", <<7::little-signed-16>>},
+        {"s32", <<7::little-signed-32>>},
+        {"s64", <<7::little-signed-64>>}
+      ]
+
+      for {dtype, bin} <- cases do
+        assert {:ok, %RecordBatch{} = batch} =
+                 RecordBatch.from_columns(["x"], [bin], [dtype], 1),
+               "expected dtype #{dtype} to succeed"
+
+        assert RecordBatch.num_rows(batch) == 1
+      end
+    end
+
+    test "all unsigned integer dtypes" do
+      cases = [
+        {"u8", <<7::unsigned-8>>},
+        {"u16", <<7::little-unsigned-16>>},
+        {"u32", <<7::little-unsigned-32>>},
+        {"u64", <<7::little-unsigned-64>>}
+      ]
+
+      for {dtype, bin} <- cases do
+        assert {:ok, %RecordBatch{} = batch} =
+                 RecordBatch.from_columns(["x"], [bin], [dtype], 1),
+               "expected dtype #{dtype} to succeed"
+
+        assert RecordBatch.num_rows(batch) == 1
+      end
+    end
+
+    test "float dtypes" do
+      cases = [
+        {"f32", <<1.5::little-float-32>>},
+        {"f64", <<1.5::little-float-64>>}
+      ]
+
+      for {dtype, bin} <- cases do
+        assert {:ok, %RecordBatch{} = batch} =
+                 RecordBatch.from_columns(["x"], [bin], [dtype], 1),
+               "expected dtype #{dtype} to succeed"
+
+        assert RecordBatch.num_rows(batch) == 1
+      end
+    end
+
+    test "bool dtype: one byte per element, non-zero is true" do
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(["b"], [<<0, 1, 0, 1>>], ["bool"], 4)
+
+      assert RecordBatch.num_rows(batch) == 4
+    end
+
+    test "multiple columns of different dtypes" do
+      assert {:ok, %RecordBatch{} = batch} =
+               RecordBatch.from_columns(
+                 ["id", "score"],
+                 [<<1::little-signed-64>>, <<3.14::little-float-64>>],
+                 ["s64", "f64"],
+                 1
+               )
+
+      assert RecordBatch.num_rows(batch) == 1
+      assert RecordBatch.num_columns(batch) == 2
+      assert RecordBatch.column_names(batch) == ["id", "score"]
+    end
+
+    test "result is a real RecordBatch struct (resource is a reference)" do
+      assert {:ok, %RecordBatch{resource: ref}} =
+               RecordBatch.from_columns(["id"], [<<1::little-signed-64>>], ["s64"], 1)
+
+      assert is_reference(ref)
+    end
+  end
+
+  describe "from_columns/4 — input validation" do
+    test "returns error when names/binaries/dtypes lengths differ" do
+      assert {:error, msg} =
+               RecordBatch.from_columns(
+                 ["a", "b"],
+                 [<<1::little-signed-64>>],
+                 ["s64", "s64"],
+                 1
+               )
+
+      assert msg =~ "same length"
+    end
+
+    test "returns error when no columns are provided" do
+      assert {:error, msg} = RecordBatch.from_columns([], [], [], 0)
+      assert msg =~ "at least one column"
+    end
+
+    test "returns error for unknown dtype" do
+      assert {:error, msg} =
+               RecordBatch.from_columns(["x"], [<<1::little-signed-64>>], ["int64"], 1)
+
+      assert msg =~ "unknown dtype"
+    end
+
+    test "returns error when binary length doesn't match length × element_size" do
+      # 8 bytes for s64 × length 2 expects 16 bytes
+      assert {:error, msg} =
+               RecordBatch.from_columns(["x"], [<<1::little-signed-64>>], ["s64"], 2)
+
+      assert msg =~ "binary length mismatch"
+    end
+
+    test "returns error for bool when binary length differs from row count" do
+      assert {:error, msg} =
+               RecordBatch.from_columns(["b"], [<<1>>], ["bool"], 4)
+
+      assert msg =~ "binary length mismatch"
+    end
+  end
 end

--- a/test/ex_arrow/record_batch_test.exs
+++ b/test/ex_arrow/record_batch_test.exs
@@ -334,4 +334,99 @@ defmodule ExArrow.RecordBatchTest do
       assert msg =~ "truncated"
     end
   end
+
+  describe "from_columns/4 — round-trip with schema and metadata" do
+    test "schema is queryable after from_columns and reflects the input names" do
+      assert {:ok, batch} =
+               RecordBatch.from_columns(
+                 ["id", "score"],
+                 [<<1::little-signed-64>>, <<3.14::little-float-64>>],
+                 ["s64", "f64"],
+                 1
+               )
+
+      schema = RecordBatch.schema(batch)
+      assert %ExArrow.Schema{} = schema
+      assert ExArrow.Schema.field_names(schema) == ["id", "score"]
+    end
+
+    test "field types in the schema match the declared dtypes" do
+      bin =
+        [
+          {"i", <<1::little-signed-32>>, "s32"},
+          {"f", <<2.0::little-float-64>>, "f64"},
+          {"b", <<1>>, "bool"},
+          {"s", <<3::little-32, "abc">>, "utf8"}
+        ]
+
+      names = Enum.map(bin, &elem(&1, 0))
+      bins = Enum.map(bin, &elem(&1, 1))
+      dtypes = Enum.map(bin, &elem(&1, 2))
+
+      assert {:ok, batch} = RecordBatch.from_columns(names, bins, dtypes, 1)
+
+      types =
+        batch
+        |> RecordBatch.schema()
+        |> ExArrow.Schema.fields()
+        |> Enum.map(& &1.type)
+
+      # The Schema NIF returns Arrow logical-type atoms (e.g. :int32 for s32).
+      # Verify that the dtypes round-trip correctly to the expected logical
+      # type, not just that *some* schema is produced.
+      assert types == [:int32, :float64, :boolean, :utf8]
+    end
+
+    test "non-nullable fields are produced by from_columns/4" do
+      assert {:ok, batch} =
+               RecordBatch.from_columns(["x"], [<<1::little-signed-64>>], ["s64"], 1)
+
+      assert [%ExArrow.Field{name: "x", type: :int64, nullable: false}] =
+               batch
+               |> RecordBatch.schema()
+               |> ExArrow.Schema.fields()
+    end
+
+    test "column_names/1 round-trip after from_columns/4" do
+      names = ["a", "b", "c"]
+
+      assert {:ok, batch} =
+               RecordBatch.from_columns(
+                 names,
+                 [
+                   <<1::little-signed-64>>,
+                   <<2::little-signed-64>>,
+                   <<3::little-signed-64>>
+                 ],
+                 ["s64", "s64", "s64"],
+                 1
+               )
+
+      assert RecordBatch.column_names(batch) == names
+    end
+
+    test "num_rows/1 reports the declared row count for fixed-width columns" do
+      bin =
+        <<1::little-signed-64, 2::little-signed-64, 3::little-signed-64, 4::little-signed-64,
+          5::little-signed-64>>
+
+      assert {:ok, batch} = RecordBatch.from_columns(["x"], [bin], ["s64"], 5)
+      assert RecordBatch.num_rows(batch) == 5
+    end
+
+    test "num_rows/1 reports the declared row count for utf8 columns" do
+      bin =
+        <<1::little-32, "a", 2::little-32, "bc", 3::little-32, "def">>
+
+      assert {:ok, batch} = RecordBatch.from_columns(["s"], [bin], ["utf8"], 3)
+      assert RecordBatch.num_rows(batch) == 3
+      assert RecordBatch.num_columns(batch) == 1
+    end
+
+    test "num_rows/1 reports zero for an empty column" do
+      assert {:ok, batch} = RecordBatch.from_columns(["s"], [<<>>], ["utf8"], 0)
+      assert RecordBatch.num_rows(batch) == 0
+      assert RecordBatch.num_columns(batch) == 1
+    end
+  end
 end

--- a/test/support/flight_sql_statement_stubs.ex
+++ b/test/support/flight_sql_statement_stubs.ex
@@ -58,6 +58,69 @@ defmodule ExArrow.FlightSQL.StmtNativeClosed do
   def flight_sql_prepared_close(_ref), do: :ok
 end
 
+# Stateful stub that models the real NIF's Mutex<Option<PreparedStatement>>
+# closed-state behaviour: the first close call succeeds and flips the
+# resource into the closed state; subsequent close calls are idempotent and
+# also return :ok; every other operation on a closed resource returns
+# :protocol_error.
+#
+# State is held in a process dictionary keyed by the calling process so
+# tests using this stub remain isolated when run async: false.
+defmodule ExArrow.FlightSQL.StmtNativeStatefulClose do
+  @moduledoc false
+  @key :__ex_arrow_stmt_stub_state__
+
+  @doc "Reset the stub state for the current process."
+  def reset, do: Process.put(@key, %{closed?: false, calls: 0})
+
+  @doc "Whether close has been observed at least once."
+  def closed?, do: state().closed?
+
+  @doc "Total number of close calls observed."
+  def call_count, do: state().calls
+
+  defp state do
+    Process.get(@key) || %{closed?: false, calls: 0}
+  end
+
+  defp put_state(s), do: Process.put(@key, s)
+
+  defp ensure_state do
+    case Process.get(@key) do
+      nil ->
+        s = %{closed?: false, calls: 0}
+        Process.put(@key, s)
+        s
+
+      s ->
+        s
+    end
+  end
+
+  def flight_sql_prepared_close(_ref) do
+    s = ensure_state()
+    put_state(%{s | closed?: true, calls: s.calls + 1})
+    :ok
+  end
+
+  def flight_sql_prepared_execute(_ref), do: closed_or_ok({:ok, :fake_stream_ref})
+
+  def flight_sql_prepared_execute_update(_ref), do: closed_or_ok({:ok, 5})
+
+  def flight_sql_prepared_bind(_ref, _batch_ref), do: closed_or_ok(:ok)
+
+  def flight_sql_prepared_parameter_schema(_ref),
+    do: closed_or_ok({:ok, :fake_schema_ref})
+
+  defp closed_or_ok(default) do
+    if state().closed? do
+      {:error, {:protocol_error, 0, "statement is closed"}}
+    else
+      default
+    end
+  end
+end
+
 # Returns a binary (non-tuple) error -- exercises the binary clause of wrap_nif_error.
 defmodule ExArrow.FlightSQL.StmtNativeBinaryError do
   @moduledoc false

--- a/test/support/flight_sql_statement_stubs.ex
+++ b/test/support/flight_sql_statement_stubs.ex
@@ -2,15 +2,18 @@
 # Inject via:
 #   Application.put_env(:ex_arrow, :flight_sql_statement_native, ExArrow.FlightSQL.StmtNative*)
 
-# Returns a successful stream ref for execute/1 — used to test the happy path
+# Returns a successful stream ref for execute/1 -- used to test the happy path
 # without a live NIF resource.
 defmodule ExArrow.FlightSQL.StmtNativeOk do
   @moduledoc false
   def flight_sql_prepared_execute(_ref), do: {:ok, :fake_stream_ref}
   def flight_sql_prepared_execute_update(_ref), do: {:ok, 5}
+  def flight_sql_prepared_bind(_ref, _batch_ref), do: :ok
+  def flight_sql_prepared_parameter_schema(_ref), do: {:ok, :fake_schema_ref}
+  def flight_sql_prepared_close(_ref), do: :ok
 end
 
-# Returns {:ok, :unknown} for execute_update — server did not report a row count.
+# Returns {:ok, :unknown} for execute_update -- server did not report a row count.
 defmodule ExArrow.FlightSQL.StmtNativeUnknown do
   @moduledoc false
   def flight_sql_prepared_execute_update(_ref), do: {:ok, :unknown}
@@ -24,13 +27,25 @@ defmodule ExArrow.FlightSQL.StmtNativeError do
 
   def flight_sql_prepared_execute_update(_ref),
     do: {:error, {:permission_denied, 7, "read-only"}}
+
+  def flight_sql_prepared_bind(_ref, _batch_ref),
+    do: {:error, {:invalid_argument, 3, "schema mismatch"}}
+
+  def flight_sql_prepared_parameter_schema(_ref),
+    do: {:error, {:unimplemented, 12, "parameter schema not available"}}
+
+  def flight_sql_prepared_close(_ref),
+    do: {:error, {:server_error, 13, "close failed"}}
 end
 
-# Returns a binary (non-tuple) error — exercises the binary clause of wrap_nif_error.
+# Returns a binary (non-tuple) error -- exercises the binary clause of wrap_nif_error.
 defmodule ExArrow.FlightSQL.StmtNativeBinaryError do
   @moduledoc false
   def flight_sql_prepared_execute(_ref), do: {:error, "stream failed"}
   def flight_sql_prepared_execute_update(_ref), do: {:error, "dml failed"}
+  def flight_sql_prepared_bind(_ref, _batch_ref), do: {:error, "bind failed"}
+  def flight_sql_prepared_parameter_schema(_ref), do: {:error, "schema failed"}
+  def flight_sql_prepared_close(_ref), do: :ok
 end
 
 # Also add a stub for flight_sql_prepare in ClientImpl tests.

--- a/test/support/flight_sql_statement_stubs.ex
+++ b/test/support/flight_sql_statement_stubs.ex
@@ -121,6 +121,35 @@ defmodule ExArrow.FlightSQL.StmtNativeStatefulClose do
   end
 end
 
+# Recording stub: captures the (stmt_ref, batch_ref) pair handed to
+# flight_sql_prepared_bind so tests can verify the Elixir layer forwards
+# the right resource references unchanged.  State is per-process to keep
+# tests isolated.
+defmodule ExArrow.FlightSQL.StmtNativeRecording do
+  @moduledoc false
+  @key :__ex_arrow_stmt_recording__
+
+  def reset, do: Process.put(@key, %{last_bind: nil})
+
+  def last_bind_call do
+    state = Process.get(@key) || %{last_bind: nil}
+    state.last_bind
+  end
+
+  def flight_sql_prepared_bind(stmt_ref, batch_ref) do
+    state = Process.get(@key) || %{last_bind: nil}
+    Process.put(@key, %{state | last_bind: {stmt_ref, batch_ref}})
+    :ok
+  end
+
+  # Pass-through implementations for the other operations so the stub can
+  # be used in lifecycle tests without exploding.
+  def flight_sql_prepared_execute(_ref), do: {:ok, :fake_stream_ref}
+  def flight_sql_prepared_execute_update(_ref), do: {:ok, 0}
+  def flight_sql_prepared_parameter_schema(_ref), do: {:ok, :fake_schema_ref}
+  def flight_sql_prepared_close(_ref), do: :ok
+end
+
 # Returns a binary (non-tuple) error -- exercises the binary clause of wrap_nif_error.
 defmodule ExArrow.FlightSQL.StmtNativeBinaryError do
   @moduledoc false

--- a/test/support/flight_sql_statement_stubs.ex
+++ b/test/support/flight_sql_statement_stubs.ex
@@ -38,6 +38,26 @@ defmodule ExArrow.FlightSQL.StmtNativeError do
     do: {:error, {:server_error, 13, "close failed"}}
 end
 
+# Models the NIF behaviour for an already-closed statement: every operation
+# (other than close, which is idempotent) returns :protocol_error.
+defmodule ExArrow.FlightSQL.StmtNativeClosed do
+  @moduledoc false
+  def flight_sql_prepared_execute(_ref),
+    do: {:error, {:protocol_error, 0, "statement is closed"}}
+
+  def flight_sql_prepared_execute_update(_ref),
+    do: {:error, {:protocol_error, 0, "statement is closed"}}
+
+  def flight_sql_prepared_bind(_ref, _batch_ref),
+    do: {:error, {:protocol_error, 0, "statement is closed"}}
+
+  def flight_sql_prepared_parameter_schema(_ref),
+    do: {:error, {:protocol_error, 0, "statement is closed"}}
+
+  # Idempotent: real NIF returns :ok when the inner Option has already been taken.
+  def flight_sql_prepared_close(_ref), do: :ok
+end
+
 # Returns a binary (non-tuple) error -- exercises the binary clause of wrap_nif_error.
 defmodule ExArrow.FlightSQL.StmtNativeBinaryError do
   @moduledoc false


### PR DESCRIPTION
__Files Changed__

| File | 	Change
|------|-----------------
| native/ex_arrow_native/src/flight_sql.rs |	Changed stmt: Mutex<PreparedStatement> to Mutex<Option<PreparedStatement>> to support close/1. Added NIFs: flight_sql_prepared_bind, flight_sql_prepared_parameter_schema, flight_sql_prepared_close. Updated flight_sql_prepared_execute and flight_sql_prepared_execute_update to handle Option. 
| lib/ex_arrow/flight_sql/statement.ex	|Rewrote: added bind/2, parameter_schema/1, close/1, closed field on struct. All operations check closed state and return {:error, %Error{code: :protocol_error}} on closed statements. 
| lib/ex_arrow/flight_sql/client.ex	|Updated prepare/2 docs to reflect bind/close support. | lib/ex_arrow/flight_sql.ex	|Updated module doc to list bind/close in supported features, removed "v0.6.0" deferral note. 
| lib/ex_arrow/native.ex	|Added NIF stubs for flight_sql_prepared_bind, flight_sql_prepared_parameter_schema, flight_sql_prepared_close. 
| lib/ex_arrow/record_batch.ex	|Added from_columns/4 — creates a RecordBatch from column-oriented binary data.
 | test/ex_arrow/flight_sql_statement_test.exs	|Added tests for bind/2, parameter_schema/1, close/1, closed-statement error paths, and lifecycle (bind-execute-close).
 | test/support/flight_sql_statement_stubs.ex	|Added flight_sql_prepared_bind, flight_sql_prepared_parameter_schema, flight_sql_prepared_close to all stubs. 
| CHANGELOG.md	|Added v0.6.1 section with all changes.

__Tests Added__
- bind/2 — success, schema mismatch, closed statement
- parameter_schema/1 — success, unimplemented, closed statement
- close/1 — success, idempotent, server error
- Closed statement error paths for execute/1, execute_update/1, bind/2, parameter_schema/1
- Full lifecycle test (bind → execute → close)
- Updated existing stub modules for new NIFs

__Known Limitations__
- close/1 sends ActionClosePreparedStatement to the server. Servers that don't support this action will return an error. The Elixir side always marks the statement as closed, preventing further use regardless of server response.
- Multi-row parameter binding depends on server support. The API accepts any RecordBatch, but servers may reject batches with more than one row for ? placeholders.
- No RecordBatch.from_rows/1 — the prompt requested this, but the existing NIF only supports column-oriented construction. from_columns/4 is provided instead, which is the Arrow-native approach.

Add Flight SQL prepared statement parameter binding

- Statement.bind/2 binds Arrow RecordBatch parameters before execution
- Statement.close/1 sends ActionClosePreparedStatement (idempotent)
- Statement.parameter_schema/1 inspects expected parameter types
- RecordBatch.from_columns/4 creates batches for parameter binding
- FlightSqlPreparedStatementResource stores Option<PreparedStatement> to support clean close that consumes the statement handle
- All operations on closed statements return protocol_error
- 87 stub-based unit tests passing

-closed #210
-closed #211
-closed #212
-closed #213