### PR TITLE
Prepare v0.7.2 release: GenStage optional-dep fix and docs refresh.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-07-08
+
+### Fixed
+
+- **`ExArrow.GenStage.*Producer` without `:gen_stage`**: the 0.7.1 module-attribute
+  guard still expanded `use GenStage` in some compile contexts (e.g. `Mix.install`
+  without `{:gen_stage, ...}` in deps, or stale cached builds). Producers are now
+  wrapped in a file-level `if Code.ensure_loaded?(GenStage)` block (same pattern
+  as `AdbcPackagePool`), so `ex_arrow` compiles when GenStage is absent.
+
 ## [0.7.1] - 2026-06-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![CI](https://github.com/thanos/ex_arrow/actions/workflows/ci.yml/badge.svg)](https://github.com/thanos/ex_arrow/actions/workflows/ci.yml)
 [![Hex version](https://img.shields.io/hexpm/v/ex_arrow.svg)](https://hex.pm/packages/ex_arrow)
-[![Hex docs](https://img.shields.io/badge/docs-hexdocs.pm-blue)](https://hexdocs.pm/ex_arrow)
+[![Hex docs](https://img.shields.io/badge/docs-hexdocs.pm-blue)](https://ex-arrow.hexdocs.pm)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Coverage Status](https://coveralls.io/repos/github/thanos/ex_arrow/badge.svg?branch=main)](https://coveralls.io/github/thanos/ex_arrow?branch=main)
 
 
 Native Apache Arrow for the BEAM: IPC streaming, Arrow Flight, Arrow Flight SQL, ADBC database bindings, and Arrow-native pipelines. Column data lives in Rust buffers; Elixir holds lightweight opaque handles. Precompiled NIFs for Linux, macOS, and Windows — no Rust required to use.
 
-> **v0.7.0 — Arrow-native pipelines.** New: `ExArrow.Stream` constructors for every source, `ExArrow.Batch` transforms, `ExArrow.Pipeline` DSL, `ExArrow.Flow` / `ExArrow.GenStage` / `ExArrow.Broadway` integrations, `ExArrow.Sink.*` destinations, and `ExArrow.Telemetry` events. The unit of execution is the Arrow `RecordBatch`. See [What's changed in v0.7.0](#whats-changed-in-v070).
+> **v0.7.2 — stability release.** Fixes optional `:gen_stage` compile issues in some `Mix.install` / cached-build paths. For feature overview, see [What's changed in v0.7.0](#whats-changed-in-v070).
 
 ---
 
@@ -232,11 +232,11 @@ For **path dependencies** in Livebook (`Mix.install`), open notebooks from
 is detected) or use the Hex package:
 
 ```elixir
-Mix.install([{:ex_arrow, "~> 0.7.0"}, {:rustler, "~> 0.36", optional: true}])
+Mix.install([{:ex_arrow, "~> 0.7.2"}, {:rustler, "~> 0.36", optional: true}])
 ```
 
 Alternatively, use the published Hex package so the precompiled NIF is used
-and no Rust is needed: `Mix.install([{:ex_arrow, "~> 0.7.0"}])`.
+and no Rust is needed: `Mix.install([{:ex_arrow, "~> 0.7.2"}])`.
 
 ---
 
@@ -396,7 +396,7 @@ Interactive notebooks (open in [Livebook](https://livebook.dev)):
 - **[03 ADBC](livebook/03_adbc.livemd)** — Database, Connection, Statement, Stream (`:adbc_package` in Livebook).
 - **[04 ADBC integration](livebook/04_adbc_integration.livemd)** — Connection pooling with NimblePool.
 
-See [livebook/README.md](livebook/README.md) for run instructions.  Notebooks use Hex `~> 0.7.0` by default; opening from `livebook/` in a clone builds from source.
+See [livebook/README.md](livebook/README.md) for run instructions.  Notebooks use Hex `~> 0.7.2` by default; opening from `livebook/` in a clone builds from source.
 
 ---
 
@@ -1065,11 +1065,55 @@ The CI workflow posts a PR alert comment when any scenario regresses more than
 - [ADBC guide](docs/adbc_guide.md) — driver loading, metadata, binding
 - [Benchmarks guide](docs/benchmarks.md) — suites, CI publishing, interpreting results
 
-API reference: `mix docs` or [hexdocs.pm/ex_arrow](https://hexdocs.pm/ex_arrow).
+API reference: `mix docs` or [ex-arrow.hexdocs.pm](https://ex-arrow.hexdocs.pm).
 
 ---
 
 ## Development
+
+### How to build the project
+
+Use this flow for a clean local build:
+
+```bash
+mix clean
+mix deps.get
+mix compile
+```
+
+ExArrow uses precompiled NIFs by default. To force a local Rust build of the
+NIF (recommended when developing the native code), run:
+
+```bash
+mix clean
+EX_ARROW_BUILD=1 mix compile
+```
+
+### How to test the project
+
+Run the test suite:
+
+```bash
+mix test
+```
+
+If you see many failures with `:nif_not_loaded`, stale artifacts are usually the
+cause. Rebuild from clean:
+
+```bash
+mix clean
+EX_ARROW_BUILD=1 mix compile
+mix test
+```
+
+Optional ADBC integration tests require installed drivers/environment setup.
+If those are not available locally, skip ADBC-tagged tests:
+
+```bash
+mix test --exclude adbc --exclude adbc_package --exclude adbc_integration
+```
+
+Common contributor checks:
 
 ```bash
 mix deps.get

--- a/docs/adbc_guide.md
+++ b/docs/adbc_guide.md
@@ -130,6 +130,98 @@ batch = ExArrow.Stream.next(stream)
 # Consume until nil
 ```
 
+## Local testing
+
+You can test ADBC locally without a dedicated "dummy ADBC service".
+
+### Fast path: `:adbc_package` (SQLite in-memory)
+
+This is the easiest local check and does not require running PostgreSQL/DuckDB:
+
+```bash
+mix test --include adbc_package test/ex_arrow/adbc_package_test.exs
+```
+
+If you hit teardown flakes or `:nif_not_loaded` after dependency/build changes,
+reset and rebuild first:
+
+```bash
+mix clean
+EX_ARROW_BUILD=1 mix compile
+mix test --include adbc_package test/ex_arrow/adbc_package_test.exs
+```
+
+### PostgreSQL integration (`:adbc_integration`)
+
+Start a local PostgreSQL container:
+
+```bash
+docker run --name exarrow-pg -d \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_DB=postgres \
+  -p 5432:5432 postgres:16
+```
+
+Run integration tests:
+
+```bash
+PG_HOST=localhost \
+PG_PORT=5432 \
+PG_USER=postgres \
+PG_PASSWORD=postgres \
+PG_DATABASE=postgres \
+mix test --include adbc_integration test/ex_arrow/adbc_integration_test.exs
+```
+
+If PostgreSQL ADBC is not on your system path, set:
+`PG_ADBC_DRIVER=/path/to/libadbc_driver_postgresql.so` (or `.dylib`).
+
+On macOS, `driver_name: "adbc_driver_postgresql"` usually searches for a
+`.dylib`, but Python wheels may install a `.so` instead. In that case, set
+`PG_ADBC_DRIVER` explicitly to the installed file path.
+
+Find the installed PostgreSQL driver file from Python:
+
+```bash
+python - <<'PY'
+import pathlib
+import adbc_driver_postgresql
+p = pathlib.Path(adbc_driver_postgresql.__file__).parent
+for pattern in ("**/libadbc_driver_postgresql*.so", "**/libadbc_driver_postgresql*.dylib"):
+    matches = list(p.glob(pattern))
+    if matches:
+        print(matches[0])
+        break
+else:
+    raise SystemExit("No PostgreSQL ADBC shared library found in adbc_driver_postgresql package")
+PY
+```
+
+Then run:
+
+```bash
+PG_ADBC_DRIVER=/absolute/path/to/libadbc_driver_postgresql.so \
+PG_HOST=localhost \
+PG_PORT=5432 \
+PG_USER=postgres \
+PG_PASSWORD=postgres \
+PG_DATABASE=postgres \
+mix test --include adbc_integration test/ex_arrow/adbc_integration_test.exs
+```
+
+### DuckDB integration (`:adbc_integration`)
+
+Point tests at your DuckDB ADBC driver:
+
+```bash
+DUCKDB_DRIVER=/path/to/libduckdb.so \
+DUCKDB_DATABASE=:memory: \
+mix test --include adbc_integration test/ex_arrow/adbc_integration_test.exs
+```
+
+On macOS the library is typically a `.dylib`.
+
 ## When no driver is available
 
 ExUnit does not support skipping a test dynamically from `setup`. The ADBC integration test therefore **fails with a clear message** when the driver cannot be opened (instead of passing), so that missing driver setup is visible when running `mix test --include adbc`. Use `mix test --exclude adbc` to omit it when no driver is installed.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -3,6 +3,13 @@
 The main overview, installation, quick start, and usage examples live in the
 [README on GitHub](https://github.com/thanos/ex_arrow/blob/main/README.md).
 
+## v0.7.2 stability update
+
+v0.7.2 fixes optional `:gen_stage` compilation in `Mix.install` and cached-build
+paths where `ex_arrow` could be compiled without `{:gen_stage, ...}` and fail at
+compile time. `ExArrow.GenStage.*Producer` modules are now gated at file scope,
+so `ex_arrow` compiles cleanly when `:gen_stage` is absent.
+
 ## What's changed in v0.7.0
 
 v0.7.0 adds Arrow-native streaming and pipeline infrastructure.  The unit of
@@ -55,4 +62,4 @@ New guides: [05 Arrow pipelines overview](05_arrow_pipelines_overview.md),
 | `ExArrow.GenStage.*Producer` | `{:gen_stage, "~> 1.2"}` | Demand-driven producers: `ParquetProducer`, `FlightProducer`, `ADBCProducer` |
 | `ExArrow.Broadway` | `{:broadway, "~> 1.0"}` | Ingestion pipelines: `BatchBuilder`, `ParquetSink`, `FlightSink` |
 
-API reference: `mix docs` or [Hex Docs](https://hexdocs.pm/ex_arrow).
+API reference: `mix docs` or [ex-arrow.hexdocs.pm](https://ex-arrow.hexdocs.pm).

--- a/lib/ex_arrow/gen_stage.ex
+++ b/lib/ex_arrow/gen_stage.ex
@@ -158,28 +158,26 @@ defmodule ExArrow.GenStage do
   end
 end
 
-defmodule ExArrow.GenStage.ParquetProducer do
-  @moduledoc """
-  A `GenStage` producer that emits `ExArrow.RecordBatch` values from a Parquet
-  file or in-memory Parquet binary.
+if Code.ensure_loaded?(GenStage) do
+  defmodule ExArrow.GenStage.ParquetProducer do
+    @moduledoc """
+    A `GenStage` producer that emits `ExArrow.RecordBatch` values from a Parquet
+    file or in-memory Parquet binary.
 
-  ## Options
+    ## Options
 
-  - `:path` — path to a `.parquet` file (opened with
-    `ExArrow.Stream.from_parquet/1`).
-  - `:binary` — in-memory Parquet bytes (opened with
-    `ExArrow.Stream.from_parquet_binary/1`).
-  - `:stream` — a pre-opened `ExArrow.Stream.t()` (useful for testing).
+    - `:path` — path to a `.parquet` file (opened with
+      `ExArrow.Stream.from_parquet/1`).
+    - `:binary` — in-memory Parquet bytes (opened with
+      `ExArrow.Stream.from_parquet_binary/1`).
+    - `:stream` — a pre-opened `ExArrow.Stream.t()` (useful for testing).
 
-  ## Example
+    ## Example
 
-      {:ok, producer} =
-        ExArrow.GenStage.ParquetProducer.start_link(path: "/data/events.parquet")
-  """
+        {:ok, producer} =
+          ExArrow.GenStage.ParquetProducer.start_link(path: "/data/events.parquet")
+    """
 
-  @gen_stage_available Code.ensure_loaded?(GenStage)
-
-  if @gen_stage_available do
     use GenStage
 
     alias ExArrow.GenStage.State
@@ -240,30 +238,19 @@ defmodule ExArrow.GenStage.ParquetProducer do
     def terminate(_reason, state) do
       ExArrow.GenStage.terminate(state)
     end
-  else
-    @doc false
-    @spec start_link(keyword()) :: {:error, String.t()}
-    def start_link(_opts) do
-      {:error,
-       "GenStage is not available. Add {:gen_stage, \"~> 1.2\"} to your mix.exs dependencies."}
-    end
   end
-end
 
-defmodule ExArrow.GenStage.FlightProducer do
-  @moduledoc """
-  A `GenStage` producer that emits `ExArrow.RecordBatch` values from a Flight
-  `do_get` stream.
+  defmodule ExArrow.GenStage.FlightProducer do
+    @moduledoc """
+    A `GenStage` producer that emits `ExArrow.RecordBatch` values from a Flight
+    `do_get` stream.
 
-  ## Options
+    ## Options
 
-  - `:client` + `:ticket` — opened with `ExArrow.Stream.from_flight/2`.
-  - `:stream` — a pre-opened `ExArrow.Stream.t()` (useful for testing).
-  """
+    - `:client` + `:ticket` — opened with `ExArrow.Stream.from_flight/2`.
+    - `:stream` — a pre-opened `ExArrow.Stream.t()` (useful for testing).
+    """
 
-  @gen_stage_available Code.ensure_loaded?(GenStage)
-
-  if @gen_stage_available do
     use GenStage
 
     alias ExArrow.GenStage.State
@@ -318,32 +305,21 @@ defmodule ExArrow.GenStage.FlightProducer do
     def terminate(_reason, state) do
       ExArrow.GenStage.terminate(state)
     end
-  else
-    @doc false
-    @spec start_link(keyword()) :: {:error, String.t()}
-    def start_link(_opts) do
-      {:error,
-       "GenStage is not available. Add {:gen_stage, \"~> 1.2\"} to your mix.exs dependencies."}
-    end
   end
-end
 
-defmodule ExArrow.GenStage.ADBCProducer do
-  @moduledoc """
-  A `GenStage` producer that emits `ExArrow.RecordBatch` values from an ADBC
-  query result stream.
+  defmodule ExArrow.GenStage.ADBCProducer do
+    @moduledoc """
+    A `GenStage` producer that emits `ExArrow.RecordBatch` values from an ADBC
+    query result stream.
 
-  ## Options
+    ## Options
 
-  - `:statement` — a pre-built `ExArrow.ADBC.Statement.t()` (executed with
-    `ExArrow.Stream.from_adbc/1`).
-  - `:connection` + `:sql` — opened with `ExArrow.Stream.from_adbc/2`.
-  - `:stream` — a pre-opened `ExArrow.Stream.t()` (useful for testing).
-  """
+    - `:statement` — a pre-built `ExArrow.ADBC.Statement.t()` (executed with
+      `ExArrow.Stream.from_adbc/1`).
+    - `:connection` + `:sql` — opened with `ExArrow.Stream.from_adbc/2`.
+    - `:stream` — a pre-opened `ExArrow.Stream.t()` (useful for testing).
+    """
 
-  @gen_stage_available Code.ensure_loaded?(GenStage)
-
-  if @gen_stage_available do
     use GenStage
 
     alias ExArrow.GenStage.State
@@ -404,8 +380,31 @@ defmodule ExArrow.GenStage.ADBCProducer do
     def terminate(_reason, state) do
       ExArrow.GenStage.terminate(state)
     end
-  else
-    @doc false
+  end
+else
+  defmodule ExArrow.GenStage.ParquetProducer do
+    @moduledoc false
+
+    @spec start_link(keyword()) :: {:error, String.t()}
+    def start_link(_opts) do
+      {:error,
+       "GenStage is not available. Add {:gen_stage, \"~> 1.2\"} to your mix.exs dependencies."}
+    end
+  end
+
+  defmodule ExArrow.GenStage.FlightProducer do
+    @moduledoc false
+
+    @spec start_link(keyword()) :: {:error, String.t()}
+    def start_link(_opts) do
+      {:error,
+       "GenStage is not available. Add {:gen_stage, \"~> 1.2\"} to your mix.exs dependencies."}
+    end
+  end
+
+  defmodule ExArrow.GenStage.ADBCProducer do
+    @moduledoc false
+
     @spec start_link(keyword()) :: {:error, String.t()}
     def start_link(_opts) do
       {:error,

--- a/livebook/00_quickstart.livemd
+++ b/livebook/00_quickstart.livemd
@@ -35,7 +35,7 @@ local? = File.exists?(Path.join(__DIR__, "../native/ex_arrow_native/Cargo.toml")
     }
   else
     {
-      {:ex_arrow, "~> 0.7.0"},
+      {:ex_arrow, "~> 0.7.2"},
       [],
       [adbc: [drivers: [:sqlite]]]
     }
@@ -162,7 +162,7 @@ ExArrow.Flight.Server.stop(server)
 
 With ADBC you open a database (e.g. SQLite), run SQL, and get an **Arrow stream** of result batches—same `ExArrow.Stream` API as IPC and Flight.
 
-This cell uses the **`:adbc_package`** backend (see [03 ADBC](03_adbc.livemd) and [04 ADBC integration](04_adbc_integration.livemd)): the [`adbc`](https://hex.pm/packages/adbc) package downloads SQLite; ExArrow returns `ExArrow.Stream` batches without a native `.dylib`. For native C drivers in production, see [Installing an ADBC driver](INSTALL_ADBC_DRIVER.md).
+This cell uses the **`:adbc_package`** backend (see [03 ADBC](03_adbc.livemd) and [04 ADBC integration](04_adbc_integration.livemd)): the [`adbc`](https://hex.pm/packages/adbc) package downloads SQLite; ExArrow returns `ExArrow.Stream` batches without a native `.dylib`. For native C drivers in production, see [Installing an ADBC driver](INSTALL_ADBC_DRIVER.md). API docs: [ADBC guide](https://ex-arrow.hexdocs.pm/adbc_guide.html), [`ExArrow.ADBC.Database`](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Database.html), [`ExArrow.ADBC.Statement`](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Statement.html).
 
 ```elixir
 :ok = Adbc.download_driver!(:sqlite)
@@ -337,4 +337,4 @@ _ = ExArrow.Stream.to_list(stream3)
 :telemetry.detach("ex-arrow-quickstart")
 ```
 
-Docs: [hexdocs.pm/ex_arrow](https://hexdocs.pm/ex_arrow).
+Docs: [ex-arrow.hexdocs.pm](https://ex-arrow.hexdocs.pm) · [ADBC guide](https://ex-arrow.hexdocs.pm/adbc_guide.html).

--- a/livebook/01_ipc.livemd
+++ b/livebook/01_ipc.livemd
@@ -31,7 +31,7 @@ local? = File.exists?(Path.join(__DIR__, "../native/ex_arrow_native/Cargo.toml")
     }
   else
     {
-      {:ex_arrow, "~> 0.7.0"},
+      {:ex_arrow, "~> 0.7.2"},
       [],
       [adbc: [drivers: [:sqlite]]]
     }

--- a/livebook/02_flight.livemd
+++ b/livebook/02_flight.livemd
@@ -31,7 +31,7 @@ local? = File.exists?(Path.join(__DIR__, "../native/ex_arrow_native/Cargo.toml")
     }
   else
     {
-      {:ex_arrow, "~> 0.7.0"},
+      {:ex_arrow, "~> 0.7.2"},
       [],
       [adbc: [drivers: [:sqlite]]]
     }

--- a/livebook/03_adbc.livemd
+++ b/livebook/03_adbc.livemd
@@ -31,7 +31,7 @@ local? = File.exists?(Path.join(__DIR__, "../native/ex_arrow_native/Cargo.toml")
     }
   else
     {
-      {:ex_arrow, "~> 0.7.0"},
+      {:ex_arrow, "~> 0.7.2"},
       [],
       [adbc: [drivers: [:sqlite]]]
     }
@@ -46,15 +46,21 @@ ADBC exposes databases through the Arrow Database Connectivity API. You open a *
 
 This notebook covers: opening a database, executing SQL, consuming the result stream, and optional metadata APIs.
 
+### Documentation
+
+- [ADBC guide](https://ex-arrow.hexdocs.pm/adbc_guide.html) — driver loading, `:adbc_package` backend, pooling, local testing
+- API reference: [ExArrow.ADBC.Database](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Database.html), [ExArrow.ADBC.Connection](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Connection.html), [ExArrow.ADBC.Statement](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Statement.html), [ExArrow.ADBC.DriverHelper](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.DriverHelper.html), [ExArrow.ADBC.ConnectionPool](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.ConnectionPool.html)
+- Package overview: [ex-arrow.hexdocs.pm](https://ex-arrow.hexdocs.pm)
+
 ---
 
 ## 1. Concepts
 
-| Handle     | Module                    | Purpose                                                          |
-| ---------- | ------------------------- | ---------------------------------------------------------------- |
-| Database   | `ExArrow.ADBC.Database`   | Driver (path or name) + init options (e.g. URI).                 |
-| Connection | `ExArrow.ADBC.Connection` | Session from a database.                                         |
-| Statement  | `ExArrow.ADBC.Statement`  | Set SQL, execute → returns `ExArrow.Stream` of record batches. |
+| Handle     | Module                                                                 | Purpose                                                          |
+| ---------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Database   | [`ExArrow.ADBC.Database`](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Database.html)   | Driver (path or name) + init options (e.g. URI).                 |
+| Connection | [`ExArrow.ADBC.Connection`](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Connection.html) | Session from a database.                                         |
+| Statement  | [`ExArrow.ADBC.Statement`](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Statement.html)  | Set SQL, execute → returns `ExArrow.Stream` of record batches. |
 
 Flow: **Database.open** → **Connection.open** → **Statement.new(conn, sql)** → **execute** → **Stream** (schema + next).
 
@@ -65,7 +71,7 @@ Flow: **Database.open** → **Connection.open** → **Statement.new(conn, sql)**
 ExArrow supports two ways to reach a database:
 
 * **`:adbc_package` backend (this notebook)** — uses the [`adbc`](https://hex.pm/packages/adbc) Hex package to download SQLite and query via supervised `Adbc.Database` / `Adbc.Connection`. Results are converted to `ExArrow.Stream`. **No native ADBC `.dylib` required** — works in Livebook.
-* **Native C driver** — ExArrow’s NIF loads `libadbc_driver_sqlite.dylib` (or `.so`) via the ADBC driver manager. Use `driver_path:` or `driver_name:` + `ADBC_DRIVER`. See [Installing an ADBC driver](INSTALL_ADBC_DRIVER.md).
+* **Native C driver** — ExArrow’s NIF loads `libadbc_driver_sqlite.dylib` (or `.so`) via the ADBC driver manager. Use `driver_path:` or `driver_name:` + `ADBC_DRIVER`. See [Installing an ADBC driver](INSTALL_ADBC_DRIVER.md) and the [ADBC guide](https://ex-arrow.hexdocs.pm/adbc_guide.html).
 
 `DriverHelper.ensure_driver_and_open/2` calls `Adbc.download_driver/1` then opens by `driver_name`; that only works when a **loadable C driver** is on disk. In Livebook, prefer `:adbc_package` instead.
 
@@ -264,3 +270,5 @@ end
 * **Connection pooling** with the adbc package: see [04_adbc_integration.livemd](04_adbc_integration.livemd).
 
 You’ve now seen **IPC**, **Flight**, and **ADBC**. ExArrow keeps Arrow data in native memory and gives you a single stream/batch API across all three—ideal for pipelines, ETL, and interchanging with Explorer or other Arrow consumers.
+
+Further reading: [ADBC guide](https://ex-arrow.hexdocs.pm/adbc_guide.html) · [ex-arrow.hexdocs.pm](https://ex-arrow.hexdocs.pm)

--- a/livebook/04_adbc_integration.livemd
+++ b/livebook/04_adbc_integration.livemd
@@ -31,7 +31,7 @@ local? = File.exists?(Path.join(__DIR__, "../native/ex_arrow_native/Cargo.toml")
     }
   else
     {
-      {:ex_arrow, "~> 0.7.0"},
+      {:ex_arrow, "~> 0.7.2"},
       [],
       [adbc: [drivers: [:sqlite]]]
     }
@@ -43,6 +43,12 @@ Mix.install(deps ++ [ex_arrow_dep] ++ extra_deps, config: config)
 ## Section
 
 This notebook demonstrates the **adbc_package** backend: a single Livebook-friendly integration that uses the [`adbc`](https://hex.pm/packages/adbc) package (and optional **NimblePool**) so you can query a database and get `ExArrow.Stream` results without loading a native ADBC driver. It also demos **connection pooling** when `nimble_pool` is available.
+
+### Documentation
+
+- [ADBC guide](https://ex-arrow.hexdocs.pm/adbc_guide.html) — `:adbc_package` backend and connection pooling
+- API reference: [ExArrow.ADBC.Database](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Database.html), [ExArrow.ADBC.Connection](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Connection.html), [ExArrow.ADBC.Statement](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.Statement.html), [ExArrow.ADBC.ConnectionPool](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.ConnectionPool.html)
+- Package overview: [ex-arrow.hexdocs.pm](https://ex-arrow.hexdocs.pm)
 
 ---
 
@@ -165,3 +171,5 @@ IO.inspect(results, label: "Concurrent query results")
 * **Setup**: Configure `:ex_arrow, :adbc_package` (e.g. `[driver: :sqlite, uri: ":memory:"]`) and optionally `:adbc_package_pool_size`. If the manager wasn’t started by the application (e.g. in Livebook), start it with `AdbcPackageManager.start_link/0`.
 * **Flow**: `Database.open(:adbc_package)` → `Connection.open(db)` → `Statement.new(conn, sql)` → `execute` → `ExArrow.Stream` (schema + next), same as in [Tutorial 3: ADBC](03_adbc.livemd).
 * **Pooling**: With `pool_size > 1` and `nimble_pool` in deps, the backend uses a connection pool so multiple concurrent executes can run in parallel.
+
+Further reading: [ADBC guide](https://ex-arrow.hexdocs.pm/adbc_guide.html) · [ExArrow.ADBC.ConnectionPool](https://ex-arrow.hexdocs.pm/ExArrow.ADBC.ConnectionPool.html) · [ex-arrow.hexdocs.pm](https://ex-arrow.hexdocs.pm)

--- a/livebook/README.md
+++ b/livebook/README.md
@@ -26,13 +26,13 @@ Together they demonstrate ExArrow functionality: IPC (stream + file), Flight (cl
 | Where you open the notebook | `ex_arrow` source |
 |----------------------------|-------------------|
 | From `livebook/` in a git clone | Local path + `EX_ARROW_BUILD=1` (compile NIF from Rust) |
-| From Livebook autosave or elsewhere | Hex `~> 0.7.0` (precompiled NIF, no Rust) |
+| From Livebook autosave or elsewhere | Hex `~> 0.7.2` (precompiled NIF, no Rust) |
 
 ### ADBC in Livebook
 
 Notebooks **00**, **03**, and **04** use the [`adbc`](https://hex.pm/packages/adbc) package to download the SQLite driver.  Tutorials **03** and **04** use ExArrow’s **`:adbc_package`** backend so you get `ExArrow.Stream` results **without** a native ADBC `.dylib`.
 
-For production deployments with a native C driver (PostgreSQL, DuckDB, etc.), see [Installing an ADBC driver](INSTALL_ADBC_DRIVER.md) and [docs/adbc_guide.md](../docs/adbc_guide.md).
+For production deployments with a native C driver (PostgreSQL, DuckDB, etc.), see [Installing an ADBC driver](INSTALL_ADBC_DRIVER.md) and the [ADBC guide on HexDocs](https://ex-arrow.hexdocs.pm/adbc_guide.html). Package overview: [ex-arrow.hexdocs.pm](https://ex-arrow.hexdocs.pm).
 
 ### Local development tips
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExArrow.MixProject do
   use Mix.Project
 
-  @version "0.7.1"
+  @version "0.7.2"
   @source_url "https://github.com/thanos/ex_arrow"
 
   def project do
@@ -42,7 +42,7 @@ defmodule ExArrow.MixProject do
       maintainers: ["Thanos Vassilakis"],
       links: %{
         "GitHub" => @source_url,
-        "Docs" => "https://hexdocs.pm/ex_arrow",
+        "Docs" => "https://ex-arrow.hexdocs.pm",
         "Changelog" => "#{@source_url}/blob/main/CHANGELOG.md"
       },
       files: [

--- a/native/ex_arrow_native/Cargo.lock
+++ b/native/ex_arrow_native/Cargo.lock
@@ -464,7 +464,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ex_arrow_native"
-version = "0.6.3"
+version = "0.7.2"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/native/ex_arrow_native/Cargo.toml
+++ b/native/ex_arrow_native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ex_arrow_native"
-version = "0.6.3"
+version = "0.7.2"
 edition = "2021"
 description = "Apache Arrow NIFs for ExArrow Elixir library"
 license = "Apache-2.0"

--- a/test/ex_arrow/adbc_package_test.exs
+++ b/test/ex_arrow/adbc_package_test.exs
@@ -35,21 +35,15 @@ defmodule ExArrow.ADBC.AdbcPackageTest do
     Application.delete_env(:ex_arrow, :adbc_package)
     Application.delete_env(:ex_arrow, :adbc_package_pool_size)
 
-    if pid = Process.whereis(ExArrow.ADBC.AdbcPackageManager) do
-      GenServer.stop(pid, :shutdown, 5_000)
-      Process.sleep(50)
-    end
+    stop_adbc_package_manager()
+    Process.sleep(50)
 
     {:ok, _} = AdbcPackageManager.start_link()
 
     on_exit(fn ->
-      pid = Process.whereis(ExArrow.ADBC.AdbcPackageManager)
-
-      if is_pid(pid) and Process.alive?(pid) do
-        # :shutdown (not :normal) propagates exit to linked stub processes from
-        # AdbcDbStub / AdbcConnStub spawn_link; :normal would leave them sleeping.
-        GenServer.stop(pid, :shutdown, 5_000)
-      end
+      # Another test module or a linked stub may already have stopped the manager
+      # between whereis/1 and stop/3; treat that as success.
+      stop_adbc_package_manager()
 
       if saved_package != nil, do: Application.put_env(:ex_arrow, :adbc_package, saved_package)
 
@@ -58,6 +52,22 @@ defmodule ExArrow.ADBC.AdbcPackageTest do
     end)
 
     :ok
+  end
+
+  defp stop_adbc_package_manager do
+    case Process.whereis(ExArrow.ADBC.AdbcPackageManager) do
+      pid when is_pid(pid) ->
+        try do
+          # :shutdown (not :normal) propagates exit to linked stub processes from
+          # AdbcDbStub / AdbcConnStub spawn_link; :normal would leave them sleeping.
+          GenServer.stop(pid, :shutdown, 5_000)
+        catch
+          :exit, _ -> :ok
+        end
+
+      _ ->
+        :ok
+    end
   end
 
   # Fake db/conn/pool pids that sleep forever: spawn_link + on_exit kill so nothing


### PR DESCRIPTION
Fix ExArrow.GenStage.*Producer compilation when :gen_stage is absent by gating producers at file scope, matching the AdbcPackagePool pattern. Bump to 0.7.2, add changelog/release notes, and update README, ADBC guide, and livebooks (Hex ~> 0.7.2, ex-arrow.hexdocs.pm links, local build/test and ADBC integration instructions). Harden adbc_package test teardown.
 - closed #241